### PR TITLE
fix wrong mainnet

### DIFF
--- a/src/components/Wallet.tsx
+++ b/src/components/Wallet.tsx
@@ -27,9 +27,7 @@ const Wallet = (props: any) => {
   const { unsupportedChainid } = useContext(MainnetContext)
 
   useEffect(() => {
-    setConnected(
-      !!account && (!!chainId && [envs.requiredChainId, envs.bscMainnetChainId].includes(chainId))
-    );
+    setConnected(!!account);
   }, [account, chainId]);
 
   return (


### PR DESCRIPTION
이제 wallet 에서 connected의 역할은, 지갑이 연결되어 있느냐만 검사하도록 변경했습니다.

어차피 올바른 네트워크인가에 대한 검증은 이미 unsupportedChainid에서 t/f를 전달해주고 있어서,
둘의 역할이 충돌나서 (--connected 클래스가 안 붙고, unknown-chain 도 나오는 상황...) 오류가 나고 있었습니다 ㅠㅠ