### PR TITLE
EL-47 메인넷에 따른 데이터 검증 필터

### DIFF
--- a/src/clients/OffChainTopic.ts
+++ b/src/clients/OffChainTopic.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosResponse } from 'axios';
+import MainnetType from 'src/enums/MainnetType';
 
 export interface TopicList {
   topic_list: {
@@ -25,6 +26,7 @@ export interface INapData {
   totalVoters: number;
   link: string;
   endedDate: string;
+  network: MainnetType;
 }
 
 export default class OffChainTopic {

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -28,7 +28,7 @@ const Footer = () => {
           </div>
         </div>
       </div>
-      <h2>ⓒ 2021 | ELYFI | All rights reserved.</h2>
+      <h2>ⓒ 2021·2022 | ELYFI | All rights reserved.</h2>
     </footer>
   );
 };

--- a/src/containers/Governance.tsx
+++ b/src/containers/Governance.tsx
@@ -38,7 +38,6 @@ const Governance = () => {
   const { t } = useTranslation();
   const History = useHistory();
   const { lng } = useParams<{ lng: string }>();
-  const { type: getMainnetType } = useContext(MainnetContext)
   const assetBondTokensBackedByEstate = assetBondTokens.filter((product) => {
     const parsedId = parseTokenId(product.id);
     return CollateralCategory.Others !== parsedId.collateralCategory
@@ -104,6 +103,7 @@ const Governance = () => {
             const getHTMLStringData: string =
               getNATData.data.post_stream.posts[0].cooked.toString();
             const regexNap = /NAP#: .*(?=<)/;
+            const regexNetwork = /Network: .*(?=<)/;
             setOffChainNapData((napData) => [
               ...napData,
               {
@@ -125,6 +125,7 @@ const Governance = () => {
                 link: `https://forum.elyfi.world/t/${getNATData.data.slug}`,
                 endedDate:
                   getNATData.data.post_stream.posts[0].polls[0].close || '',
+                network: (!!getHTMLStringData.match(regexNetwork)) === true ? MainnetType.BSC : MainnetType.Ethereum
               } as INapData,
             ]);
           });
@@ -346,7 +347,7 @@ const Governance = () => {
             <div>
               <h3>
                 {t('governance.data_verification', {
-                  count: offChainNapData.filter((data) => {
+                  count: offChainNapData.filter((data) => data.network === mainnetType).filter((data) => {
                     return moment().isBefore(data.endedDate);
                   }).length,
                 })}
@@ -372,7 +373,7 @@ const Governance = () => {
               <div>
                 <h3>
                   {t('governance.data_verification', {
-                    count: offChainNapData.filter((data) =>
+                    count: offChainNapData.filter((data) => data.network === mainnetType).filter((data) =>
                       moment().isBefore(data.endedDate),
                     ).length,
                   })}
@@ -396,11 +397,11 @@ const Governance = () => {
 
           {offChainLoading ? (
             <Skeleton width={'100%'} height={600} />
-          ) : offChainNapData.filter((data) =>
+          ) : offChainNapData.filter((data) => data.network === mainnetType).filter((data) =>
               moment().isBefore(data.endedDate),
             ).length > 0 ? (
             <div className="governance__grid">
-              {offChainNapData.map((data, index) => {
+              {offChainNapData.filter((data) => data.network === mainnetType).map((data, index) => {
                 if (data.endedDate && moment().isBefore(data.endedDate)) {
                   return offChainContainer(data);
                 }
@@ -422,7 +423,7 @@ const Governance = () => {
               <div>
                 <p>{t('governance.on_chain_voting__content')}</p>
                 {
-                  getMainnetType === MainnetType.Ethereum && (
+                  mainnetType === MainnetType.Ethereum && (
                     <a
                       href="https://www.withtally.com/governance/elyfi"
                       target="_blank"
@@ -448,7 +449,7 @@ const Governance = () => {
                   })}
                 </h3>
                 {
-                  getMainnetType === MainnetType.Ethereum && (
+                  mainnetType === MainnetType.Ethereum && (
                     <a
                       href="https://www.withtally.com/governance/elyfi"
                       target="_blank"
@@ -468,7 +469,7 @@ const Governance = () => {
             </div>
           )}
           {
-            getMainnetType === MainnetType.Ethereum ? (
+            mainnetType === MainnetType.Ethereum ? (
               onChainLoading ? (
                 <Skeleton width={'100%'} height={600} />
               ) : onChainData.length > 0 ? (

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -279,7 +279,7 @@
 
     "staking": {
       "staking__token": "{{ token }} Staking",
-      "staking__notice": "{{ stakedToken }} Staking will be carried out in four separate sessions according to the {{ rewardToken }} mining plan.\nStaking {{ stakedToken }} tokens reward the {{ rewardToken }} tokens, and the staked {{ stakedToken }} tokens can be unstaken at any time.\n\n* In addition, {{ stakedToken }} tokens staked in the previous round and the rewarded {{ rewardToken }} tokens are not automatically sent to the next staking pool.",
+      "staking__notice": "{{ stakedToken }} Staking will be carried out in six separate sessions according to the {{ rewardToken }} mining plan.\nStaking {{ stakedToken }} tokens reward the {{ rewardToken }} tokens, and the staked {{ stakedToken }} tokens can be unstaken at any time.\n\n* In addition, {{ stakedToken }} tokens staked in the previous round and the rewarded {{ rewardToken }} tokens are not automatically sent to the next staking pool.",
       "staking__nth": "{{ nth }} round staking",
       "current_round_null": "There is no current rounds in progress.",
       "staking__in_progress": "<strong>{{ nth }}</strong> round In Progress",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -270,7 +270,7 @@
       "on_chain_voting__content": "This is a list of proposals for which voting is in progress in on-chain governance(DAO).",
       "loan_list": "Loan list ({{ count }} case)",
       "loan_list_plural": "Loan list ({{ count }} cases)",
-      "loan_list__content": "Loans executed in DAI Money Pool according to the decision of the Governance (DAO).",
+      "loan_list__content": "Loans executed in Money Pool according to the decision of the Governance (DAO).",
       "onchain_list_zero": "There are currently no on-chain votes in progress.",
       "offchain_list_zero": "There are currently no data verification votes in progress.",
       "forum_button": "Go to ELYFI Forum",

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -279,7 +279,7 @@
     },
     "staking": {
       "staking__token": "{{ token }} 스테이킹",
-      "staking__notice": "{{ stakedToken }} 스테이킹은 {{ rewardToken }} 채굴 플랜에 따라 4차례로 나눠서 진행됩니다.\n{{ stakedToken }} 토큰을 스테이킹하면 {{ rewardToken }} 토큰을 리워드로 받게 되며, 스테이킹한 {{ stakedToken }} 토큰은 언제든지 언스테이킹이 가능합니다.\n\n* 이전 회차에 스테이킹한 {{ stakedToken }} 토큰과 보상 받은 {{ rewardToken }} 토큰은 다음 회차의 스테이킹 풀에 자동으로 전송되지 않습니다.",
+      "staking__notice": "{{ stakedToken }} 스테이킹은 {{ rewardToken }} 채굴 플랜에 따라 6차례로 나눠서 진행됩니다.\n{{ stakedToken }} 토큰을 스테이킹하면 {{ rewardToken }} 토큰을 리워드로 받게 되며, 스테이킹한 {{ stakedToken }} 토큰은 언제든지 언스테이킹이 가능합니다.\n\n* 이전 회차에 스테이킹한 {{ stakedToken }} 토큰과 보상 받은 {{ rewardToken }} 토큰은 다음 회차의 스테이킹 풀에 자동으로 전송되지 않습니다.",
       "staking__nth": "{{ nth }}차 스테이킹",
       "current_round_null": "현재 진행중인 회차가 없습니다.",
       "staking__in_progress": "<strong>{{ nth }}차</strong> 스테이킹 진행 중",

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -271,7 +271,7 @@
       "on_chain_voting__content": "온체인 거버넌스(DAO)에서 투표가 진행중인 제안서 리스트 입니다.",
       "loan_list": "대출리스트 ({{ count }} 건)",
       "loan_list_plural": "대출리스트 ({{ count }} 건)",
-      "loan_list__content": "거버넌스(DAO)의 결정에 따라 DAI 머니풀에서 실행된 대출입니다.",
+      "loan_list__content": "거버넌스(DAO)의 결정에 따라 머니풀에서 실행된 대출입니다.",
       "onchain_list_zero": "현재 진행중인 온체인 투표가 없습니다.",
       "offchain_list_zero": "현재 진행중인 데이터 검증 투표가 없습니다.",
       "forum_button": "ELYFI 포럼으로 이동하기",


### PR DESCRIPTION
이제 governance의 Data verification에 한해서, forum에서 NFT Details > Token info의 Network 정보를 읽고 현재 네트워크 정보에 따라 filter 해서 보여주는 기능을 추가했습니다.

그 외에 해결된 이슈
* EL43 all right reserved 년도 수정
* EL26 staking 차수 6차례로 수정
* EL45 거버넌스 페이지 토큰 표현 삭제