### PR TITLE
Optimize loading performance

### DIFF
--- a/src/providers/PriceProvider.tsx
+++ b/src/providers/PriceProvider.tsx
@@ -4,8 +4,6 @@ import PriceContext, {
   initialPriceContext,
   PriceContextType,
 } from 'src/contexts/PriceContext';
-import Loading from 'src/components/Loading';
-import ErrorPage from 'src/components/ErrorPage';
 import Coingecko from 'src/clients/Coingecko';
 import calcPriceFromSqrtPriceX96 from 'src/utiles/calcPriceFromSqrtPriceX96';
 import CachedUniswapV3 from 'src/clients/CachedUniswapV3';
@@ -95,9 +93,6 @@ const PriceProvider: React.FC = (props) => {
   useEffect(() => {
     fetchPrices();
   }, []);
-
-  if (state.loading) return <Loading />;
-  if (state.error) return <ErrorPage />;
 
   return (
     <PriceContext.Provider

--- a/src/providers/SubgraphProvider.tsx
+++ b/src/providers/SubgraphProvider.tsx
@@ -10,27 +10,20 @@ const SubgraphProvider: React.FC = (props) => {
   const [loading, setLoading] = useState(true)
 
   const fetchSubgraph = async () => {
-    const mainnetData = await ReserveSubgraph.getEthReserveData()
-    const bscData = await ReserveSubgraph.getBscReserveData()
+    const reserves = await Promise.all(
+      [ReserveSubgraph.getEthReserveData, ReserveSubgraph.getBscReserveData].map(async (fetcth) => {
+      const res = await fetcth();
+      return res.data.data.reserves.map((reserve) => {
+        return {
+          ...reserve,
+          assetBondTokens: res.data.data.assetBondTokens.filter((ab) => ab.reserve.id === reserve.id)
+        }
+      })
+    }))
 
-    // FIXME
-    // Our subgraph reserve has no child like asset bond tokens at v0.4.0
     setState({
       data: {
-        reserves: [
-          ...mainnetData.data.data.reserves.map((reserve) => {
-            return {
-              ...reserve,
-              assetBondTokens: mainnetData.data.data.assetBondTokens.filter((ab) => ab.reserve.id === reserve.id)
-            }
-          }),
-          ...bscData.data.data.reserves.map((reserve) => {
-            return {
-              ...reserve,
-              assetBondTokens: bscData.data.data.assetBondTokens.filter((ab) => ab.reserve.id === reserve.id)
-            }
-          }),
-        ],
+        reserves: reserves.flat(),
       }
     })
   }

--- a/src/providers/UniswapPoolProvider.tsx
+++ b/src/providers/UniswapPoolProvider.tsx
@@ -95,16 +95,8 @@ const UniswapPoolProvider: React.FC = (props) => {
           },
           loading: false,
         });
-        // setState({
-        //   ...state,
-        //   loading: false,
-        //   error: true,
-        // });
       });
   }, []);
-
-  if (state.loading) return <Loading />;
-  if (state.error) return <ErrorPage />;
 
   return (
     <UniswapPoolContext.Provider


### PR DESCRIPTION
첫 로딩속도를 2배 빨라지도록 개선했습니다. (기존 약 4초 -> 2초)

### 문제 원인
페이지를 그리기 위해 요청해야하는 api가 여러개 있는데, 이전 요청이 끝나야만 요청이 진행되던 문제가 있었습니다.
아래의 그림이 문제를 해결하기 전인데, 1~3초의 요청을 보면 쉽게 이해할 수 있습니다. 
하나의 요청이 끝나야만 그 다음 요청을 하는 것을 확인할 수 있습니다.
<img width="347" alt="스크린샷 2022-02-09 오후 5 59 43" src="https://user-images.githubusercontent.com/69144981/153162150-8997702d-a784-41cd-8dd2-39e3fd0f11ac.png">

### 해결 방법
1. Subgraph 데이터를 불러올 때 사용하는 두 API 호출은, `Promise.all`을 이용해서 두 요청이 서로 막지 않도록 변경 
2. PriceProvider, UniswapProvider에서는 로딩되지 않아도 이후 랜더링을 막지 않도록 변경.
두 가지 방법으로 여러 api요청들을 한번에 보내도록 변경할 수 있었고, 아래와 같이 개선할 수 있었습니다.
외부 api요청들이 모두 같이 보내지고, 2초쯤 끝나는 것을 확인할 수 있습니다.
 <img width="475" alt="스크린샷 2022-02-09 오후 5 51 51" src="https://user-images.githubusercontent.com/69144981/153162680-0b01af94-938b-4287-8209-14536f763e56.png">

### 배운점
`provider-context` 패턴을 사용해서 global 상태값을 관리하기는 편했는데, 예상치 못하게 api 요청간 의존성을 부여하게되는 문제가 있었습니다. 로딩이나 에러를 처리하기 위해, 각 provider에서 처리하지 말고, App 컴포넌트와 가장 가까운 provider에서만 처리를 해주어야, 깔끔하게 api요청들을 한번에 보낼 수 있을것 같습니다.