### PR TITLE
change tally link

### DIFF
--- a/src/components/MainGovernanceTable.tsx
+++ b/src/components/MainGovernanceTable.tsx
@@ -80,7 +80,7 @@ const MainGovernanceTable: FunctionComponent<Props> = ({
               {
                 title: data.data.description.match(/NAP.*/)?.toString() || '',
                 created_at: dates,
-                link: `https://www.withtally.com/governance/elyfi/proposal/${getDataId}`,
+                link: `${t("governance.link.tally")}/proposal/${getDataId}`,
               },
             ]);
           });

--- a/src/containers/Governance.tsx
+++ b/src/containers/Governance.tsx
@@ -239,7 +239,7 @@ const Governance = () => {
             action: ButtonEventType.OnChainVoteButtonOnGovernance,
           });
           window.open(
-            `https://www.withtally.com/governance/elyfi/proposal/${data.id}`,
+            `${t("governance.link.tally")}/proposal/${data.id}`,
           );
         }}>
         <div>
@@ -449,7 +449,7 @@ const Governance = () => {
                 <p>{t('governance.on_chain_voting__content')}</p>
                 {mainnetType === MainnetType.Ethereum && (
                   <a
-                    href="https://www.withtally.com/governance/elyfi"
+                    href={`${t("governance.link.tally")}`}
                     target="_blank"
                     rel="noopener noreferer">
                     <div
@@ -473,7 +473,7 @@ const Governance = () => {
                 </h3>
                 {mainnetType === MainnetType.Ethereum && (
                   <a
-                    href="https://www.withtally.com/governance/elyfi"
+                    href={`${t("governance.link.tally")}`}
                     target="_blank"
                     rel="noopener noreferer">
                     <div

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -282,7 +282,10 @@
       "onchain_list_zero": "There are currently no on-chain votes in progress.",
       "offchain_list_zero": "There are currently no data verification votes in progress.",
       "forum_button": "Go to ELYFI Forum",
-      "onChain_tally_button": "Go to Tally"
+      "onChain_tally_button": "Go to Tally",
+      "link": {
+        "tally": "https://www.withtally.com/governance/eip155:1:0x0c54629266d7fa40B4BFaF1640ebC2Cd093866C3"
+      }
     },
 
     "staking": {

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -283,7 +283,10 @@
       "onchain_list_zero": "현재 진행중인 온체인 투표가 없습니다.",
       "offchain_list_zero": "현재 진행중인 데이터 검증 투표가 없습니다.",
       "forum_button": "ELYFI 포럼으로 이동하기",
-      "onChain_tally_button": "Tally로 이동하기"
+      "onChain_tally_button": "Tally로 이동하기",
+      "link": {
+        "tally": "https://www.withtally.com/governance/eip155:1:0x0c54629266d7fa40B4BFaF1640ebC2Cd093866C3"
+      }
     },
     "staking": {
       "staking__token": "{{ token }} 스테이킹",


### PR DESCRIPTION
tally링크가 변경됨에 따라, elyfi에서 온체인투표 제안서들을 클릭 시 페이지가 로딩이 되지 않는 이슈가 있었습니다.
이에 주소를 수정하는 김에 아예 i18n에 따로 링크를 저장하도록 해서, 추후 또 변경되더라도 수정이 쉽도록 추가로 코드를 변경했습니다.

사족으로 나중에 엘리파이 웹 내에 모든 외부 링크를 한 문서(i18n이나, 기타 json 파일 등)에 정리해 두는것도 괜찮겠네요! 이 부분은 어떻게 하면 좋을지 따로 기획해보겠습니다