### PR TITLE
fix mainnet issue + status error

### DIFF
--- a/src/containers/Governance.tsx
+++ b/src/containers/Governance.tsx
@@ -39,7 +39,6 @@ const Governance = () => {
   const History = useHistory();
   const { value: mediaQuery } = useMediaQueryType();
   const { lng } = useParams<{ lng: string }>();
-  const { type: getMainnetType } = useContext(MainnetContext);
   const assetBondTokensBackedByEstate = assetBondTokens.filter((product) => {
     const parsedId = parseTokenId(product.id);
     return CollateralCategory.Others !== parsedId.collateralCategory;
@@ -117,7 +116,7 @@ const Governance = () => {
             const getHTMLStringData: string =
               getNATData.data.post_stream.posts[0].cooked.toString();
             const regexNap = /NAP#: .*(?=<)/;
-            const regexNetwork = /Network: .*(?=<)/;
+            const regexNetwork = /Network: BSC.*(?=<)/;
             setOffChainNapData((napData) => [
               ...napData,
               {
@@ -125,7 +124,7 @@ const Governance = () => {
                 nap:
                   getHTMLStringData.match(regexNap)?.toString().substring(5) ||
                   '',
-                status: getHTMLStringData.match(/Status: .*(?=<)/) || '',
+                status: getHTMLStringData.match(/Status: .*(?=<)/)?.toString().split('Status: ') || '',
                 images:
                   getHTMLStringData
                     .match(


### PR DESCRIPTION
Network: BSC 문자열을 찾고 발견이 된다면 BSC 메인넷, 감지되지 않았다면 이더리움 메인넷에서 보이도록 변경했습니다.
(네트워크 개념이 없었을 때 등록된 게시물들은 모두 이더리움 메인넷이기 때문)

그 외에도 .split을 이용해 데이터 검증 리스트에서 status 텍스트가 노출되던 오류를 픽스했습니다