### PR TITLE
Fix/portfolio issue

### DIFF
--- a/src/containers/PortfolioDetail.tsx
+++ b/src/containers/PortfolioDetail.tsx
@@ -68,6 +68,12 @@ const PortfolioDetail: FunctionComponent = () => {
   );
   const history = useHistory();
 
+  const blockExplorerUrls = 
+    tokenInfo?.tokenizer === envs.tokenizer.busdTokenizerAddress ? 
+      envs.externalApiEndpoint.bscscanURI 
+      : 
+      envs.externalApiEndpoint.etherscanURI;
+
   const loadAddress = async (
     lat: number,
     lng: number,
@@ -234,7 +240,7 @@ const PortfolioDetail: FunctionComponent = () => {
               <div>
                 <p>{t('loan.receiving_address')}</p>
                 <a
-                  href="https://etherscan.io/address/0x9FCdc09bF1e0f933e529325Ac9D24f56034d8eD7"
+                  href={`${blockExplorerUrls}/address/${abToken?.borrower?.id}`}
                   target="_blank"
                   rel="noopener noreferer">
                   <p className={abToken?.borrower?.id ? 'link' : ''}>
@@ -282,7 +288,7 @@ const PortfolioDetail: FunctionComponent = () => {
                   className="link"
                   onClick={() => {
                     window.open(
-                      `${envs.externalApiEndpoint.etherscanURI}/token/${tokenInfo.tokenizer}?a=${abToken?.id}`,
+                      `${blockExplorerUrls}/token/${tokenInfo.tokenizer}?a=${abToken?.id}`,
                       '_blank',
                     );
                   }}>
@@ -331,7 +337,7 @@ const PortfolioDetail: FunctionComponent = () => {
                   t('loan.collateral_nft__abtoken_id'),
                   `${abToken?.id.slice(0, 8)} ... ${abToken?.id.slice(-8)}`,
                   '',
-                  `${envs.externalApiEndpoint.etherscanURI}/token/${tokenInfo.tokenizer}?a=${abToken?.id}`,
+                  `${blockExplorerUrls}/token/${tokenInfo.tokenizer}?a=${abToken?.id}`,
                 ],
                 [t('loan.collateral_nft__borrower'), 'Elyloan Inc', '', ''],
                 [

--- a/src/core/data/reserves.ts
+++ b/src/core/data/reserves.ts
@@ -27,7 +27,7 @@ export const reserveTokenData = {
     image: usdt,
     decimals: 6,
     address: envs.token.usdtAddress,
-    tokenizer: envs.tokenizer.usdtTokeninzerAddress,
+    tokenizer: envs.tokenizer.usdtTokenizerAddress,
   },
   EL: {
     name: 'EL',
@@ -52,6 +52,7 @@ export const reserveTokenData = {
     image: busd,
     decimals: 18,
     address: envs.token.busdAddress,
+    tokenizer: envs.tokenizer.busdTokenizerAddress,
   },
 };
 
@@ -61,7 +62,7 @@ const reserves: IReserve[] = [
     image: usdt,
     decimals: 6,
     address: envs.token.usdtAddress,
-    tokenizer: envs.tokenizer.usdtTokeninzerAddress,
+    tokenizer: envs.tokenizer.usdtTokenizerAddress,
   },
   {
     name: 'DAI',
@@ -93,6 +94,7 @@ const reserves: IReserve[] = [
     image: busd,
     decimals: 18,
     address: envs.token.busdAddress,
+    tokenizer: envs.tokenizer.busdTokenizerAddress,
   },
 ];
 

--- a/src/core/envs/index.ts
+++ b/src/core/envs/index.ts
@@ -6,7 +6,7 @@ interface EnvironmentVariables {
     bscMoneyPoolAddress: string;
     moneyPoolAddress: string;
     daiTokenizerAddress: string;
-    usdtTokeninzerAddress: string;
+    usdtTokenizerAddress: string;
   };
   incentivePool: {
     prevDaiIncentivePool: string;
@@ -56,7 +56,8 @@ interface EnvironmentVariables {
   };
   tokenizer: {
     daiTokenizerAddress: string;
-    usdtTokeninzerAddress: string;
+    usdtTokenizerAddress: string;
+    busdTokenizerAddress: string;
   };
   jsonRpcUrl: {
     bsc: string;

--- a/src/core/envs/prod.json
+++ b/src/core/envs/prod.json
@@ -51,7 +51,8 @@
   },
   "tokenizer": {
     "daiTokenizerAddress": "0xc6701e7be98A79485364419961838EB141141aAf",
-    "usdtTokeninzerAddress": "0x68f69Ab21242e194ebd7534B598e26180dD92616"
+    "usdtTokenizerAddress": "0x68f69Ab21242e194ebd7534B598e26180dD92616",
+    "busdTokenizerAddress": "0x0d768c1507B5099CB37e5D28B1959B831B5EbF9e"
   },
   "jsonRpcUrl": {
     "bsc": "https://bsc-dataseed.binance.org/"

--- a/src/core/envs/test.json
+++ b/src/core/envs/test.json
@@ -51,7 +51,8 @@
   },
   "tokenizer": {
     "daiTokenizerAddress": "0xc6701e7be98A79485364419961838EB141141aAf",
-    "usdtTokeninzerAddress": "0x68f69Ab21242e194ebd7534B598e26180dD92616"
+    "usdtTokenizerAddress": "0x68f69Ab21242e194ebd7534B598e26180dD92616",
+    "busdTokenizerAddress": "0x0d768c1507B5099CB37e5D28B1959B831B5EbF9e"
   },
   "jsonRpcUrl": {
     "bsc": "https://data-seed-prebsc-1-s1.binance.org:8545/"


### PR DESCRIPTION
busdTokenizerAddress를 추가하고, 현재 ABToken의 tokenizer값을 확인해 BUSD라면 BSCScan 주소를, 아니라면 ETHScan 주소를 연결합니다.

  ```
const blockExplorerUrls = 
    tokenInfo?.tokenizer === envs.tokenizer.busdTokenizerAddress ? 
      envs.externalApiEndpoint.bscscanURI 
      : 
      envs.externalApiEndpoint.etherscanURI;
```

