### PR TITLE
remove cdn & use api

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,11 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script
-      type="text/javascript"
-      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%REACT_APP_KAKAO_MAP_KEY%&libraries=services">
-    ></script>
     <?xml version='1.0' encoding='utf-8'?>
 
     <meta charset="utf-8" />

--- a/src/clients/KakaoMap.ts
+++ b/src/clients/KakaoMap.ts
@@ -1,0 +1,18 @@
+import axios from 'axios';
+
+export const cord2address = (x: number, y: number): Promise<{
+  meta: { total_count: number },
+  documents: {
+    road_address: {
+      address_name: string,
+      region_1depth_name: string,
+    }
+  }[]
+}> =>
+  axios.get(`https://dapi.kakao.com/v2/local/geo/coord2address.json?x=${x}&y=${y}`,
+    {
+      headers: {
+        "Authorization": `KakaoAK ${process.env.REACT_APP_KAKAO_MAP_KEY}`,
+        "KA": "sdk/4.4.3 os/javascript lang/ko-KR device/MacIntel origin/https%3A%2F%2Fwww.elyfi.world"
+      }
+    }).then((res) => res.data);

--- a/src/utiles/reverseGeocoding.ts
+++ b/src/utiles/reverseGeocoding.ts
@@ -1,5 +1,6 @@
 import Geocode from 'react-geocode';
 import LanguageType from 'src/enums/LanguageType';
+import { cord2address } from 'src/clients/KakaoMap';
 
 Geocode.setApiKey(process.env.REACT_APP_GOOGLE_MAP_API_KEY!);
 
@@ -16,18 +17,6 @@ const getHardKorGeocoding = (lat: number, lng: number) => {
   }
 };
 
-declare global {
-  interface Window {
-    kakao: any;
-  }
-}
-
-interface IKakaoCord2AddressResult {
-  road_address: {
-    address_name: string;
-  };
-}
-
 const reverseGeocoding = async (
   lat: number,
   lng: number,
@@ -36,28 +25,9 @@ const reverseGeocoding = async (
   try {
     if (languageType === LanguageType.KO) {
       try {
-        const geocoder = new window.kakao.maps.services.Geocoder();
-        const coord = new window.kakao.maps.LatLng(lat, lng);
+        const data = await cord2address(lng, lat);
 
-        return new Promise((resolve, reject) => {
-          geocoder.coord2Address(
-            coord.getLng(),
-            coord.getLat(),
-            (
-              result: IKakaoCord2AddressResult[],
-              status: 'OK' | 'ZERO_RESULT' | 'ERROR',
-            ) => {
-              if (status === 'OK') {
-                return resolve(
-                  result[0].road_address?.address_name ||
-                    getHardKorGeocoding(lat, lng),
-                );
-              }
-
-              reject();
-            },
-          );
-        });
+        return data.documents[0].road_address?.address_name || getHardKorGeocoding(lat, lng)
       } catch (error) {
         console.error(error);
         return '-';


### PR DESCRIPTION
kakao map CDN이 중국 ip에서 아예 로드가 되지 않고, 몇몇 해외 ip에서는 매우 느린 문제가 있었습니다.
해당 CDN을 사용하지 않는 대신, CDN 소스코드를 사용하지 않고 직접 api를 호출하도록 변경했습니다.