### PR TITLE
Feat/error tracker

### DIFF
--- a/src/components/ClaimStakingRewardModal.tsx
+++ b/src/components/ClaimStakingRewardModal.tsx
@@ -176,7 +176,7 @@ const ClaimStakingRewardModal: FunctionComponent<{
                   );
                 })
                 .catch((e) => {
-                  failTransaction(emitter, closeHandler, e);
+                  failTransaction(emitter, closeHandler, e, TransactionType.Claim);
                 });
             }}>
             <p>{t('staking.claim_reward')}</p>

--- a/src/components/MigrationModal.tsx
+++ b/src/components/MigrationModal.tsx
@@ -344,7 +344,7 @@ const MigrationModal: React.FunctionComponent<{
               })
               .catch((e) => {
                 console.error(e);
-                failTransaction(emitter, closeHandler, e);
+                failTransaction(emitter, closeHandler, e, TransactionType.Migrate);
               });
           }}>
           <p>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -418,9 +418,10 @@ const Navigation: React.FunctionComponent<{
   useEffect(() => {
     setScrollTrigger();
   }, [scrollTop]);
+
   return (
     <>
-      {txStatus === TxStatus.FAIL && error && <ErrorModal error={error} />}
+      {txStatus === TxStatus.FAIL && error && error !== "MetaMask Tx Signature: User denied transaction signature." && <ErrorModal error={error} />}
       <nav
         className={`navigation`}
         style={{

--- a/src/containers/DepositOrWithdrawModal.tsx
+++ b/src/containers/DepositOrWithdrawModal.tsx
@@ -162,7 +162,7 @@ const DepositOrWithdrawModal: FunctionComponent<{
       })
       .catch((error) => {
         window.localStorage.removeItem('@permissionTxHash');
-        failTransaction(emitter, onClose, error);
+        failTransaction(emitter, onClose, error, TransactionType.Approve);
         console.error(error);
       });
   };
@@ -204,7 +204,7 @@ const DepositOrWithdrawModal: FunctionComponent<{
         );
       })
       .catch((error) => {
-        failTransaction(emitter, onClose, error);
+        failTransaction(emitter, onClose, error, TransactionType.Deposit);
         console.error(error);
       });
   };
@@ -246,7 +246,7 @@ const DepositOrWithdrawModal: FunctionComponent<{
         );
       })
       .catch((error) => {
-        failTransaction(emitter, onClose, error);
+        failTransaction(emitter, onClose, error, TransactionType.Withdraw);
         console.error(error);
       });
   };

--- a/src/containers/IncentiveModal.tsx
+++ b/src/containers/IncentiveModal.tsx
@@ -79,7 +79,7 @@ const IncentiveModal: FunctionComponent<{
         );
       })
       .catch((error) => {
-        failTransaction(emitter, onClose, error);
+        failTransaction(emitter, onClose, error, TransactionType.Claim);
         console.error(error);
       });
   };

--- a/src/containers/StakingModal.tsx
+++ b/src/containers/StakingModal.tsx
@@ -235,7 +235,7 @@ const StakingModal: React.FunctionComponent<{
                   );
                 })
                 .catch((e) => {
-                  failTransaction(emitter, closeHandler, e);
+                  failTransaction(emitter, closeHandler, e, TransactionType.Approve);
                 });
             }}
           />
@@ -303,7 +303,7 @@ const StakingModal: React.FunctionComponent<{
                       );
                     })
                     .catch((e) => {
-                      failTransaction(emitter, closeHandler, e);
+                      failTransaction(emitter, closeHandler, e, TransactionType.Unstake);
                     });
                 }}>
                 <p>
@@ -374,7 +374,7 @@ const StakingModal: React.FunctionComponent<{
                         );
                       })
                       .catch((e) => {
-                        failTransaction(emitter, closeHandler, e);
+                        failTransaction(emitter, closeHandler, e, TransactionType.Stake);
                       });
                   }}>
                   <p>

--- a/src/contexts/TxContext.ts
+++ b/src/contexts/TxContext.ts
@@ -1,6 +1,7 @@
 import { ContractTransaction } from 'ethers';
 import { createContext } from 'react';
 import RecentActivityType from 'src/enums/RecentActivityType';
+import TransactionType from 'src/enums/TransactionType';
 import TxStatus from '../enums/TxStatus';
 
 export type TxContextType = {
@@ -24,7 +25,7 @@ export interface ITxContext extends TxContextType {
     callback: () => void,
   ) => void;
   initTransaction: (txStatus: TxStatus, txWaiting: boolean) => void;
-  failTransaction: (emitter: any, onEvent: () => void, e: any) => void;
+  failTransaction: (emitter: any, onEvent: () => void, e: any, transaction: TransactionType) => void;
   reset: () => void;
 }
 
@@ -48,6 +49,7 @@ export const initialTxContext = {
       clicked: () => void;
       created: () => void;
       canceled: () => void;
+      failed: () => void;
     },
     type: RecentActivityType,
     pending: () => void,
@@ -59,9 +61,11 @@ export const initialTxContext = {
       clicked: () => void;
       created: () => void;
       canceled: () => void;
+      failed: () => void;
     },
     onEvent: () => void,
     e: Error,
+    transaction: TransactionType
   ): void => {},
   reset: (): void => {},
 };

--- a/src/providers/TxProvider.tsx
+++ b/src/providers/TxProvider.tsx
@@ -44,7 +44,17 @@ const TxProvider: React.FunctionComponent = (props) => {
         version: ElyfiVersions.V1,
         chainId,
         address: account,
-        errorType: error
+        errorType: Number(error.code)
+        ? error.message
+        : ethersJsErrors.includes(error.code)
+        ? error.code
+        : JSON.parse(
+            '{' +
+              error.message.substring(
+                error.message.indexOf('"message"'),
+                error.message.lastIndexOf('}'),
+              ),
+          ).message,
       }),
     );
 

--- a/src/utiles/buildEventEmitter.tsx
+++ b/src/utiles/buildEventEmitter.tsx
@@ -2,7 +2,7 @@ import ReactGA from 'react-ga';
 
 const buildEventEmitter = (
   category: string, action: string, label: string
-): { clicked: () => void, created: () => void, canceled: () => void } => {
+): { clicked: () => void, created: () => void, canceled: () => void, failed: () => void } => {
   return {
     clicked: () => {
       ReactGA.event({
@@ -25,6 +25,13 @@ const buildEventEmitter = (
         label,
       });
     },
+    failed: () => {
+      ReactGA.event({
+        category,
+        action: `${action} tx is encountered an error`,
+        label,
+      })
+    }
   };
 };
 


### PR DESCRIPTION
emitter 속성에 failed 를 추가하고, failTransaction 함수에서 buildEventEmitter 를 전달하도록 만들었습니다.

전달하는 내용은 EncounteredAnError라는 새 카테고리에서 어떤 트랜잭션에서 에러가 났는지, 체인 아이디와 version, 지갑주소와 에러 타입을 전송합니다.

failTransaction function

```
...
const newEmitter = buildEventEmitter(
      "EncounteredAnError",
      transaction,
      JSON.stringify({
        version: ElyfiVersions.V1,
        chainId,
        address: account,
        errorType: error
      }),
    );

    newEmitter.failed();
...
```

