### PR TITLE
ga exception if user denied transaction

### DIFF
--- a/src/providers/TxProvider.tsx
+++ b/src/providers/TxProvider.tsx
@@ -37,6 +37,8 @@ const TxProvider: React.FunctionComponent = (props) => {
     onEvent();
     emitter.canceled();
 
+    const metamaskUserDeniedErrCode = 4001
+
     const newEmitter = buildEventEmitter(
       "EncounteredAnError",
       transaction,
@@ -57,8 +59,9 @@ const TxProvider: React.FunctionComponent = (props) => {
           ).message,
       }),
     );
-
-    newEmitter.failed();
+    if (error.code !== metamaskUserDeniedErrCode) {
+      newEmitter.failed();
+    }
 
     setState({
       ...state,


### PR DESCRIPTION
유저가 직접 트랜잭션을 거절할 때 에러 코드를 저장해서 예외처리로 지정했습니다.