### PR TITLE
change gitbook link

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -128,8 +128,8 @@
       "ELFIStake": "ELFI Staking",
       "LPStake": "LP Staking",
       "link": {
-        "docs": "https://elysia.gitbook.io/elysia.finance/v/eng/",
-        "guide": "https://elysia.gitbook.io/elyfi-user-guide/",
+        "docs": "https://docs.elyfi.world/v/eng/",
+        "guide": "https://guide.elyfi.world",
         "governance_docs": "https://elysia.gitbook.io/elyfi-user-guide/governance"
       }
     },

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -128,8 +128,8 @@
       "ELFIStake": "ELFI 스테이킹",
       "LPStake": "LP 스테이킹",
       "link": {
-        "docs": "https://elysia.gitbook.io/elysia.finance/",
-        "guide": "https://elysia.gitbook.io/elyfi-user-guide/v/korean-2/",
+        "docs": "https://docs.elyfi.world/",
+        "guide": "https://guide.elyfi.world/v/korean-2/",
         "governance_docs": "https://elysia.gitbook.io/elyfi-user-guide/v/korean-2/governance"
       }
     },


### PR DESCRIPTION
엘리파이 백서의 링크를 docs.elyfi.world으로, 유저 가이드를 guide.elyfi.world로 각 언어 설정에 맞게 변경한 브랜치입니다.
이 브랜치에서는 그 외에 다른 기능은 없습니다.