### PR TITLE
Fix/ens

### DIFF
--- a/src/core/data/mainnets.ts
+++ b/src/core/data/mainnets.ts
@@ -66,8 +66,8 @@ export const mainnets: IMainnet[] = [
     type: MainnetType.Ethereum,
     name: 'Ethereum',
     image: ETH,
-    chainId: 1,
-    chainHexId: '0x1',
+    chainId: 3,
+    chainHexId: '0x3',
     addParams: {
       chainId: '0x1',
       chainName: 'Ethereum Mainnet',
@@ -85,8 +85,8 @@ export const mainnets: IMainnet[] = [
     type: MainnetType.Ethereum,
     name: 'Ganache',
     image: ETH,
-    chainId: 1337,
-    chainHexId: '0x1',
+    chainId: 3,
+    chainHexId: '0x3',
     addParams: {
       chainId: '0x1',
       chainName: 'Ganache Mainnet',

--- a/src/core/data/mainnets.ts
+++ b/src/core/data/mainnets.ts
@@ -66,8 +66,8 @@ export const mainnets: IMainnet[] = [
     type: MainnetType.Ethereum,
     name: 'Ethereum',
     image: ETH,
-    chainId: 3,
-    chainHexId: '0x3',
+    chainId: 1,
+    chainHexId: '0x1',
     addParams: {
       chainId: '0x1',
       chainName: 'Ethereum Mainnet',
@@ -85,8 +85,8 @@ export const mainnets: IMainnet[] = [
     type: MainnetType.Ethereum,
     name: 'Ganache',
     image: ETH,
-    chainId: 3,
-    chainHexId: '0x3',
+    chainId: 1337,
+    chainHexId: '0x1',
     addParams: {
       chainId: '0x1',
       chainName: 'Ganache Mainnet',

--- a/src/hooks/useENS.ts
+++ b/src/hooks/useENS.ts
@@ -18,8 +18,15 @@ export const useENS = (address: string | null | undefined): ReturnType => {
       const { ethereum } = window;
       try {
         if (ethereum && address && ethers.utils.isAddress(address || '')) {
+          const prevprovider = new providers.JsonRpcProvider(
+            process.env.REACT_APP_JSON_RPC,
+          );
           const provider = new providers.Web3Provider(ethereum);
           const getEnsName = await provider.lookupAddress(address);
+          console.log(prevprovider);
+          console.log(provider);
+          console.log(await provider.lookupAddress(address));
+          console.log(await prevprovider.lookupAddress(address));
           if (getEnsName) setENSName(getEnsName);
         }
       } catch (e) {

--- a/src/hooks/useENS.ts
+++ b/src/hooks/useENS.ts
@@ -18,15 +18,8 @@ export const useENS = (address: string | null | undefined): ReturnType => {
       const { ethereum } = window;
       try {
         if (ethereum && address && ethers.utils.isAddress(address || '')) {
-          const prevprovider = new providers.JsonRpcProvider(
-            process.env.REACT_APP_JSON_RPC,
-          );
           const provider = new providers.Web3Provider(ethereum);
           const getEnsName = await provider.lookupAddress(address);
-          console.log(prevprovider);
-          console.log(provider);
-          console.log(await provider.lookupAddress(address));
-          console.log(await prevprovider.lookupAddress(address));
           if (getEnsName) setENSName(getEnsName);
         }
       } catch (e) {

--- a/src/hooks/useENS.ts
+++ b/src/hooks/useENS.ts
@@ -15,10 +15,9 @@ export const useENS = (address: string | null | undefined): ReturnType => {
 
   useEffect(() => {
     async function resolveENS() {
-      const { ethereum } = window;
       try {
-        if (ethereum && address && ethers.utils.isAddress(address || '')) {
-          const provider = new providers.Web3Provider(ethereum);
+        if (address && ethers.utils.isAddress(address || '')) {
+          const provider = new providers.InfuraProvider('homestead');
           const getEnsName = await provider.lookupAddress(address);
           if (getEnsName) setENSName(getEnsName);
         }

--- a/src/hooks/useENS.ts
+++ b/src/hooks/useENS.ts
@@ -15,11 +15,10 @@ export const useENS = (address: string | null | undefined): ReturnType => {
 
   useEffect(() => {
     async function resolveENS() {
+      const { ethereum } = window;
       try {
-        if (address && ethers.utils.isAddress(address) && !ensLoading) {
-          const provider = new providers.JsonRpcProvider(
-            process.env.REACT_APP_JSON_RPC,
-          );
+        if (ethereum && address && ethers.utils.isAddress(address || '')) {
+          const provider = new providers.Web3Provider(ethereum);
           const getEnsName = await provider.lookupAddress(address);
           if (getEnsName) setENSName(getEnsName);
         }


### PR DESCRIPTION
![스크린샷 2022-04-05 오후 5 51 08](https://user-images.githubusercontent.com/59865307/161716803-93757ace-44c7-4c26-88bb-ffec98d42c39.png)


해당 브랜치에서는 위처럼 ENS 이름이 다시 출력되도록 변경했습니다.

~~결론만 보면 코드 한 줄만 변경이 되었는데,, JsonRpcProvider를 Web3Provider로 변경한 뒤 window ethereum을 불러와 사용했습니다.
await provider.lookupAddress(address); 로 ENS 이름을 불러오는 구조인데, provider를 기존처럼 JsonRpcProvider를 이용해 await을 요청하면 아무런 데이터가 오지 않았습니다.~~


테스트 결과 해당 방식은 wallet connect 에서 인식을 하지 못 하는 이슈가 있어서, 다른 방법을 찾아보니 InfuraProvider('homestead')로 묶는 방법이 있었습니다.

이 방법을 쓰면 메인넷을 제외한 테스트 넷에서는 useENS에서 provider를 읽어올 수 없다는 단점이 있지만.. 어차피 wrong network로 막아놔서 작업할 수도 없으니 괜찮을 것으로 보입니다! (꼭 필요하다면 구현은 가능합니다...!)

