### PR TITLE
Feat/add import token

### DIFF
--- a/src/assets/images/copy.svg
+++ b/src/assets/images/copy.svg
@@ -1,0 +1,5 @@
+<svg id="그룹_6680" data-name="그룹 6680" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18">
+  <path id="패스_2090" data-name="패스 2090" d="M0,0H18V18H0Z" fill="none"/>
+  <rect id="사각형_6793" data-name="사각형 6793" width="9" height="9" rx="2" transform="translate(6 6)" fill="none" stroke="#6e6e6e" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+  <path id="패스_2091" data-name="패스 2091" d="M13,7V5.5A1.5,1.5,0,0,0,11.5,4h-6A1.5,1.5,0,0,0,4,5.5v6A1.5,1.5,0,0,0,5.5,13H7" transform="translate(-1 -1)" fill="none" stroke="#6e6e6e" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+</svg>

--- a/src/components/Modal/AccountModal.tsx
+++ b/src/components/Modal/AccountModal.tsx
@@ -6,7 +6,7 @@ import TxContext from 'src/contexts/TxContext';
 import Fail from 'src/assets/images/status__fail.png';
 import Confirm from 'src/assets/images/status__confirm.png';
 import NewTab from 'src/assets/images/new_tab.png';
-import Copy from 'src/assets/images/copy.png';
+import Copy from 'src/assets/images/copy.svg';
 import envs from 'src/core/envs';
 import TxStatus from 'src/enums/TxStatus';
 import Davatar from '@davatar/react';

--- a/src/components/Modal/AccountModal.tsx
+++ b/src/components/Modal/AccountModal.tsx
@@ -17,6 +17,8 @@ import MainnetType from 'src/enums/MainnetType';
 import useMediaQueryType from 'src/hooks/useMediaQueryType';
 import MediaQuery from 'src/enums/MediaQuery';
 import { setWalletConnect } from 'src/utiles/connectWallet';
+import { ImportTokenData, IImportTokens } from 'src/core/data/importTokens';
+import MetamaskIcon from 'src/assets/images/metamask@2x.png';
 
 const AccountModal: React.FunctionComponent<{
   visible: boolean;
@@ -43,17 +45,20 @@ const AccountModal: React.FunctionComponent<{
     alert('Copied!!');
   };
 
-  const addELFIToken = async (data: string[]) => {
+  const addELFIToken = async (data: IImportTokens) => {
     try {
       await window.ethereum?.request({
         method: 'wallet_watchAsset',
         params: {
           type: 'ERC20',
           options: {
-            address: data[3],
-            symbol: data[1],
-            decimals: data[2],
-            image: data[0],
+            address:
+              getMainnetType === MainnetType.Ethereum
+                ? data.mainnet.Ethereum.address
+                : data.mainnet.BSC.address,
+            symbol: data.symbol,
+            decimals: data.decimals,
+            image: data.image,
           },
         },
       });
@@ -122,25 +127,50 @@ const AccountModal: React.FunctionComponent<{
               </div>
             </a>
           </div>
-          {/* <div className="modal__account__add-tokens">
-            <h2>
-              토큰 불러오기
-            </h2>
+          <div className="modal__account__add-tokens">
+            <h2>토큰 불러오기</h2>
             <div>
-              {
-                tokenDataArray.map((data, index) => {
-                  return (
-                    <div key={index} onClick={() => addELFIToken(data)}>
-                      <img src={data[0]} />
-                      <p>
-                        {data[1]}
-                      </p>
+              {ImportTokenData.map((data, index) => {
+                const currnetAddress =
+                  getMainnetType === MainnetType.Ethereum
+                    ? data.mainnet.Ethereum.address
+                    : data.mainnet.BSC.address;
+                console.log(data);
+                return (
+                  <div key={index}>
+                    <div>
+                      <img src={data.image} />
+                      <p>{data.symbol}</p>
                     </div>
-                  )
-                })
-              }
+                    <p>{`${currnetAddress.slice(
+                      0,
+                      8,
+                    )}....${currnetAddress.slice(-8)}`}</p>
+                    <div>
+                      <div>
+                        <img
+                          title="주소 복사하기"
+                          className="copy-image"
+                          src={Copy}
+                          onClick={() => AddressCopy(currnetAddress)}
+                          style={{ cursor: 'pointer' }}
+                        />
+                      </div>
+                      <div>
+                        <img
+                          title="메타마스크에 토큰 추가"
+                          className="metamask-image"
+                          src={MetamaskIcon}
+                          style={{ cursor: 'pointer' }}
+                          onClick={() => addELFIToken(data)}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
             </div>
-          </div> */}
+          </div>
           <div className="modal__account__status">
             <p className="modal__header__name spoqa__bold">
               {t('transaction.activity__title')}

--- a/src/core/data/importTokens.ts
+++ b/src/core/data/importTokens.ts
@@ -1,0 +1,44 @@
+import MainnetType from 'src/enums/MainnetType';
+import envs from 'src/core/envs';
+import elfi from 'src/assets/images/ELFI.png';
+
+type MainnetTokenAddress = {
+  [mainnet in MainnetType]: {
+    address: string;
+  };
+};
+export interface IImportTokens {
+  symbol: string;
+  image: string;
+  decimals: number;
+  mainnet: MainnetTokenAddress;
+}
+
+export const ImportTokenData: IImportTokens[] = [
+  {
+    symbol: 'ELFI',
+    image: elfi,
+    decimals: 18,
+    mainnet: {
+      [MainnetType.Ethereum]: {
+        address: envs.token.governanceAddress,
+      },
+      [MainnetType.BSC]: {
+        address: envs.token.bscElfiAddress,
+      },
+    },
+  },
+  {
+    symbol: 'sELFI',
+    image: elfi,
+    decimals: 18,
+    mainnet: {
+      [MainnetType.Ethereum]: {
+        address: envs.staking.elfyV2StakingPoolAddress,
+      },
+      [MainnetType.BSC]: {
+        address: envs.staking.elfyBscStakingPoolAddress,
+      },
+    },
+  },
+];

--- a/src/stylesheet/mobile.scss
+++ b/src/stylesheet/mobile.scss
@@ -2895,6 +2895,48 @@ $bold: 'Inter-Bold', 'Montserrat-bold';
           }
         }
       }
+      &__add-tokens {
+        margin-top: 20px;
+        > h2 {
+          font-size: 12px;
+        }
+        > div {
+          padding: 10px;
+          border-radius: 10px;
+          margin-top: 10px;
+          > div {
+            border-radius: 10px;
+            padding: 7px 10px;
+            &:not(:last-child) {
+              margin-bottom: 10px;
+            }
+            > div {
+              > img {
+                width: 16px;
+                height: 16px;
+                &:first-child {
+                  margin-right: 8px;
+                }
+              }
+              > div {
+                > img {
+                  width: 16px;
+                  height: 16px;
+                  &:first-child {
+                    margin-right: 8px;
+                  }
+                }
+              }
+              > p {
+                font-size: 12px;
+              }
+            }
+            > p {
+              font-size: 12px;
+            }
+          }
+        }
+      }
     }
 
     &__staking {

--- a/src/stylesheet/pc.scss
+++ b/src/stylesheet/pc.scss
@@ -2427,6 +2427,45 @@ $device-width: 1190px;
             }
           }
         }
+        &__add-tokens {
+          margin-top: 25px;
+          > h2 {
+            font-size: 18px;
+          }
+          > div {
+            padding: 20px;
+            border-radius: 10px;
+            margin-top: 10px;
+            > div {
+              border-radius: 10px;
+              padding: 10px 15px;
+              &:not(:last-child) {
+                margin-bottom: 15px;
+              }
+              > div {
+                > img {
+                  width: 24px;
+                  height: 24px;
+                  &:first-child {
+                    margin-right: 12px;
+                  }
+                }
+                > div {
+                  > img {
+                    width: 24px;
+                    height: 24px;
+                    &:first-child {
+                      margin-right: 12px;
+                    }
+                  }
+                }
+              }
+              > p {
+                font-size: 15px;
+              }
+            }
+          }
+        }
       }
 
       &__staking {

--- a/src/stylesheet/public.scss
+++ b/src/stylesheet/public.scss
@@ -3244,33 +3244,51 @@ input[type='number'] {
           color: $font-color;
         }
         > div {
-          display: grid;
+          display: flex;
+          flex-direction: column;
           width: 100%;
-          grid-template-columns: repeat(2, 1fr);
           align-items: center;
-          gap: 15px 30px;
           padding: 20px;
           border: 1px solid $gray-line;
           border-radius: 10px;
           margin-top: 10px;
           > div {
-            @include hover__box-shadow;
             display: flex;
             flex-direction: row;
             align-items: center;
             justify-content: space-between;
             box-shadow: 0px 0px 6px #00000029;
-            border-radius: 40px;
+            border-radius: 10px;
+            width: 100%;
             padding: 10px 15px;
-            cursor: pointer;
-            > img {
-              width: 24px;
-              height: 24px;
+            &:not(:last-child) {
+              margin-bottom: 15px;
+            }
+            > div {
+              display: flex;
+              flex-direction: row;
+              align-items: center;
+              > img {
+                width: 24px;
+                height: 24px;
+                &:first-child {
+                  margin-right: 12px;
+                }
+              }
+              > div {
+                position: relative;
+                > img {
+                  width: 24px;
+                  height: 24px;
+                  &:first-child {
+                    margin-right: 12px;
+                  }
+                }
+              }
             }
             > p {
-              font-size: 18px;
+              font-size: 15px;
               color: $font-color;
-              cursor: pointer;
             }
           }
         }

--- a/src/stylesheet/public.scss
+++ b/src/stylesheet/public.scss
@@ -3237,10 +3237,8 @@ input[type='number'] {
         }
       }
       &__add-tokens {
-        margin-top: 25px;
         width: 100%;
         > h2 {
-          font-size: 18px;
           color: $font-color;
         }
         > div {
@@ -3248,46 +3246,23 @@ input[type='number'] {
           flex-direction: column;
           width: 100%;
           align-items: center;
-          padding: 20px;
           border: 1px solid $gray-line;
-          border-radius: 10px;
-          margin-top: 10px;
           > div {
             display: flex;
             flex-direction: row;
             align-items: center;
             justify-content: space-between;
             box-shadow: 0px 0px 6px #00000029;
-            border-radius: 10px;
             width: 100%;
-            padding: 10px 15px;
-            &:not(:last-child) {
-              margin-bottom: 15px;
-            }
             > div {
               display: flex;
               flex-direction: row;
               align-items: center;
-              > img {
-                width: 24px;
-                height: 24px;
-                &:first-child {
-                  margin-right: 12px;
-                }
-              }
               > div {
                 position: relative;
-                > img {
-                  width: 24px;
-                  height: 24px;
-                  &:first-child {
-                    margin-right: 12px;
-                  }
-                }
               }
             }
             > p {
-              font-size: 15px;
               color: $font-color;
             }
           }


### PR DESCRIPTION
토큰들의 address 정보를 가져와서 account modal에서 import 할 수 있도록 추가했습니다.

![스크린샷 2022-04-05 오후 9 46 35](https://user-images.githubusercontent.com/59865307/161756671-75eadb0d-8789-4683-8a49-1c0dd4cd2185.png)

각 토큰 import 참조 주소는 아래와 같습니다

ELFI - Ethereum : envs.token.governanceAddress
ELFI - BSC : envs.token.bscElfiAddress

sELFI - Ethereum : envs.staking.elfyV2StakingPoolAddress
sELFI - BSC : envs.staking.elfyBscStakingPoolAddress