### PR TITLE
fix external link

### DIFF
--- a/src/components/Navigation/index.tsx
+++ b/src/components/Navigation/index.tsx
@@ -7,7 +7,13 @@ import {
   lazy,
   Suspense,
 } from 'react';
-import { Link, Outlet, useLocation, useParams } from 'react-router-dom';
+import {
+  Link,
+  Outlet,
+  useLocation,
+  useNavigate,
+  useParams,
+} from 'react-router-dom';
 import ElysiaLogo from 'src/assets/images/Elysia_Logo.png';
 import NavigationType from 'src/enums/NavigationType';
 import {
@@ -53,6 +59,8 @@ const Navigation: React.FunctionComponent<{
 }> = ({ hamburgerBar, setHamburgerBar }) => {
   // Hover Value
   const [globalNavHover, setGlobalNavHover] = useState(0);
+
+  const nav = useNavigate();
 
   // Type.LNB Dropdown Nav Seleted
   const [selectedLocalNavIndex, setSelectedLocalNavIndex] = useState(0);
@@ -130,26 +138,44 @@ const Navigation: React.FunctionComponent<{
     index: number,
   ) => {
     return (
-      <Link
-        key={`nav_${index}`}
-        to={{
-          pathname: !isExternalLink
-            ? `/${lng + _data.location}`
-            : t(_data.location),
-        }}
-        target={isExternalLink ? '_blank' : undefined}
-        onMouseEnter={() => {
-          setSelectedLocalNavIndex(0);
-        }}
-        onClick={() => {
-          initialNavigationState();
-        }}
-        className="navigation__bottom__link">
-        <div className="navigation__link">
-          <p>{t(_data.i18nKeyword).toUpperCase()}</p>
-          {isExternalLink && <img src={ExternalLinkImage} />}
-        </div>
-      </Link>
+      <>
+        {isExternalLink ? (
+          <a
+            key={`nav_${index}`}
+            href={t(_data.location)}
+            target="_blank"
+            onMouseEnter={() => {
+              setSelectedLocalNavIndex(0);
+            }}
+            onClick={() => {
+              initialNavigationState();
+            }}
+            className="navigation__bottom__link">
+            <div className="navigation__link">
+              <p>{t(_data.i18nKeyword).toUpperCase()}</p>
+              <img src={ExternalLinkImage} />
+            </div>
+          </a>
+        ) : (
+          <Link
+            key={`nav_${index}`}
+            to={{
+              pathname: `/${lng + _data.location}`,
+            }}
+            target={isExternalLink ? '_blank' : undefined}
+            onMouseEnter={() => {
+              setSelectedLocalNavIndex(0);
+            }}
+            onClick={() => {
+              initialNavigationState();
+            }}
+            className="navigation__bottom__link">
+            <div className="navigation__link">
+              <p>{t(_data.i18nKeyword).toUpperCase()}</p>
+            </div>
+          </Link>
+        )}
+      </>
     );
   };
 

--- a/src/components/Navigation/index.tsx
+++ b/src/components/Navigation/index.tsx
@@ -7,13 +7,7 @@ import {
   lazy,
   Suspense,
 } from 'react';
-import {
-  Link,
-  Outlet,
-  useLocation,
-  useNavigate,
-  useParams,
-} from 'react-router-dom';
+import { Link, Outlet, useLocation, useParams } from 'react-router-dom';
 import ElysiaLogo from 'src/assets/images/Elysia_Logo.png';
 import NavigationType from 'src/enums/NavigationType';
 import {
@@ -59,8 +53,6 @@ const Navigation: React.FunctionComponent<{
 }> = ({ hamburgerBar, setHamburgerBar }) => {
   // Hover Value
   const [globalNavHover, setGlobalNavHover] = useState(0);
-
-  const nav = useNavigate();
 
   // Type.LNB Dropdown Nav Seleted
   const [selectedLocalNavIndex, setSelectedLocalNavIndex] = useState(0);

--- a/src/components/Navigation/index.tsx
+++ b/src/components/Navigation/index.tsx
@@ -272,12 +272,8 @@ const Navigation: React.FunctionComponent<{
       <Link
         key={_index}
         to={{
-          pathname:
-            _data.type === NavigationType.Link
-              ? `/${lng + _data.location}`
-              : t(_data.location),
+          pathname: `/${lng + _data.location}`,
         }}
-        target={isExternalLink ? '_blank' : undefined}
         onMouseEnter={() => {
           setGlobalNavHover(_index + 1);
 
@@ -340,20 +336,12 @@ const Navigation: React.FunctionComponent<{
                 }}>
                 <div className="navigation__hamburger__lnb__sub-navigation__wrapper">
                   {data.subNavigation!.map((_data, index) => {
-                    return (
+                    return _data.type === NavigationType.Link ? (
                       <Link
                         key={`hamburgerBar_${index}`}
                         to={{
-                          pathname:
-                            _data.type === NavigationType.Link
-                              ? `/${lng + _data.location}`
-                              : t(_data.location),
+                          pathname: `/${lng + _data.location}`,
                         }}
-                        target={
-                          _data.type === NavigationType.Href
-                            ? '_blank'
-                            : undefined
-                        }
                         onClick={() => {
                           if (index === 0) {
                             reactGA.event({
@@ -367,6 +355,24 @@ const Navigation: React.FunctionComponent<{
                           <p>{t(_data.i18nKeyword).toUpperCase()}</p>
                         </div>
                       </Link>
+                    ) : (
+                      <a
+                        key={`hamburgerBar_${index}`}
+                        href={t(_data.location)}
+                        target="_blank"
+                        onClick={() => {
+                          if (index === 0) {
+                            reactGA.event({
+                              category: PageEventType.MoveToInternalPage,
+                              action: ButtonEventType.DepositButtonOnTop,
+                            });
+                          }
+                          setHamburgerBar(false);
+                        }}>
+                        <div>
+                          <p>{t(_data.i18nKeyword).toUpperCase()}</p>
+                        </div>
+                      </a>
                     );
                   })}
                 </div>


### PR DESCRIPTION
외부 링크가 이상하게 출력되던 이슈를 수정했습니다.

갑자기 이렇게 된 원인이 뭔가 보니, router가 v6로 넘어오면서 CSR 성능 때문에 react-router-dom의 모든 path를 상대경로만 사용하도록 변경했다는데, 아마 이 문제 때문에 링크가 깨진것으로 보입니다.
그래서 공식 문서를 참고해봤는데, 따로 external link를 지원 하려는것 같아서 기존 html의 anchor태그로 변경했습니다.

혹시 다른 링크들도 이럴까봐 점검해봤는데 다행히도 window.open 태그 등을 사용하고 있어서 아마 이 네비게이션만 수정하면 모두 해결될 것 같습니다.