### PR TITLE
update url

### DIFF
--- a/src/clients/Slate.ts
+++ b/src/clients/Slate.ts
@@ -18,7 +18,7 @@ export interface ISlateResponse {
   }[];
 }
 
-const baseUrl = 'https://slate.textile.io/ipfs';
+const baseUrl = 'https://elysia-public.s3.ap-northeast-2.amazonaws.com/elyfi-v1';
 
 export class Slate {
   static fetctABTokenIpfs = async (


### PR DESCRIPTION
Slate의 json data를 요청할때, 502에러가 발생하고 있어 긴급하게 s3로 동일한 데이터를 제공하는 것으로 변경했습니다.