### PR TITLE
use elysia s3 provider form imgage

### DIFF
--- a/src/clients/Slate.ts
+++ b/src/clients/Slate.ts
@@ -18,7 +18,7 @@ export interface ISlateResponse {
   }[];
 }
 
-const baseUrl = 'https://elysia-public.s3.ap-northeast-2.amazonaws.com/elyfi-v1';
+export const baseUrl = 'https://elysia-public.s3.ap-northeast-2.amazonaws.com/ipfs';
 
 export class Slate {
   static fetctABTokenIpfs = async (

--- a/src/components/AssetList/AssetItem.tsx
+++ b/src/components/AssetList/AssetItem.tsx
@@ -1,7 +1,7 @@
 import { FunctionComponent, lazy, Suspense, useEffect, useState } from 'react';
 import { toCompactForBignumber, toPercent } from 'src/utiles/formatters';
 import { useTranslation } from 'react-i18next';
-import Slate from 'src/clients/Slate';
+import Slate, { baseUrl } from 'src/clients/Slate';
 import ReserveData from 'src/core/data/reserves';
 import { IAssetBond } from 'src/core/types/reserveSubgraph';
 import Skeleton from 'react-loading-skeleton';
@@ -33,7 +33,7 @@ const AssetItem: FunctionComponent<{
     }
     try {
       const response = await Slate.fetctABTokenIpfs(abToken.ipfsHash || '');
-      setImage(response.data.images[0]?.link);
+      setImage(`${baseUrl}/${response.data.images[0]?.hash}`)
     } catch (error) {
       console.error(error);
     }


### PR DESCRIPTION
이미지를 불러올때도, 임시방편으로 우선 elysia가 제공하는 s3 데이터를 이용하도록 변경했습니다.

장기적으로는 slate.host에서 사용하고 있는 cloudflare가 502로 응답주는것을 해결할 방법을 찾아야 합니다!