### PR TITLE
Fix/loan data

### DIFF
--- a/cypress/integration/deposit.test.ts
+++ b/cypress/integration/deposit.test.ts
@@ -14,7 +14,7 @@ describe('Deposit page', () => {
   });
   it('BUSD detail page', () => {
     cy.get('.deposit__table__header').click();
-    cy.url().should('include', '/ko/deposits/BUSD');
+    cy.url().should('include', '/ko/deposit/BUSD');
     cy.get('.component__text-navigation > p.pointer').click();
     cy.url().should('include', '/ko/deposit');
   });
@@ -32,7 +32,7 @@ describe('Deposit page', () => {
     cy.get(
       '.deposit__table__wrapper > div:nth-child(1) > div.deposit__table__header',
     ).click();
-    cy.url().should('include', '/ko/deposits/DAI');
+    cy.url().should('include', '/ko/deposit/DAI');
     cy.get('.component__text-navigation > p.pointer').click();
     cy.url().should('include', '/ko/deposit');
   });
@@ -40,7 +40,7 @@ describe('Deposit page', () => {
     cy.get(
       '.deposit__table__wrapper > div:nth-child(2) > div.deposit__table__header',
     ).click();
-    cy.url().should('include', '/ko/deposits/USDT');
+    cy.url().should('include', '/ko/deposit/USDT');
     cy.get('.component__text-navigation > p.pointer').click();
     cy.url().should('include', '/ko/deposit');
   });

--- a/src/AppNavigator.tsx
+++ b/src/AppNavigator.tsx
@@ -139,6 +139,16 @@ const AppNavigator: React.FC = () => {
               </Suspense>
             }
           />
+          <Route path="deposit">
+            <Route
+              path=":id"
+              element={
+                <Suspense fallback={nullFallbackArea()}>
+                  <MarketDetail />
+                </Suspense>
+              }
+            />
+          </Route>
           <Route
             path="governance"
             element={
@@ -163,16 +173,6 @@ const AppNavigator: React.FC = () => {
               element={
                 <Suspense fallback={nullFallbackArea()}>
                   <RewardPlan />
-                </Suspense>
-              }
-            />
-          </Route>
-          <Route path="deposits">
-            <Route
-              path=":id"
-              element={
-                <Suspense fallback={nullFallbackArea()}>
-                  <MarketDetail />
                 </Suspense>
               }
             />

--- a/src/assets/images/undefined_image.svg
+++ b/src/assets/images/undefined_image.svg
@@ -1,0 +1,8 @@
+<svg id="그룹_6681" data-name="그룹 6681" xmlns="http://www.w3.org/2000/svg" width="106.226" height="106.226" viewBox="0 0 106.226 106.226">
+  <path id="패스_2092" data-name="패스 2092" d="M0,0H106.226V106.226H0Z" fill="none"/>
+  <line id="선_9957" data-name="선 9957" x2="80.091" y2="80.091" transform="translate(12.967 12.967)" fill="none" stroke="#b7b7b7" stroke-linecap="round" stroke-linejoin="round" stroke-width="5"/>
+  <line id="선_9958" data-name="선 9958" transform="translate(66.361 35.088)" fill="none" stroke="#b7b7b7" stroke-linecap="round" stroke-linejoin="round" stroke-width="5"/>
+  <path id="패스_2093" data-name="패스 2093" d="M70.927,70.931a13.278,13.278,0,0,1-9.388,3.886H17.278A13.278,13.278,0,0,1,4,61.539V17.278A13.252,13.252,0,0,1,7.93,7.846M21.7,4H61.539A13.278,13.278,0,0,1,74.817,17.278V57.113" transform="translate(13.704 13.704)" fill="none" stroke="#b7b7b7" stroke-linecap="round" stroke-linejoin="round" stroke-width="5"/>
+  <path id="패스_2094" data-name="패스 2094" d="M4,31l17.7-17.7c4.107-3.952,9.171-3.952,13.278,0l22.13,22.13" transform="translate(13.704 35.392)" fill="none" stroke="#b7b7b7" stroke-linecap="round" stroke-linejoin="round" stroke-width="5"/>
+  <path id="패스_2095" data-name="패스 2095" d="M16.32,12.372a9.319,9.319,0,0,1,7.436,2.921l8.852,8.852" transform="translate(55.914 42.246)" fill="none" stroke="#b7b7b7" stroke-linecap="round" stroke-linejoin="round" stroke-width="5"/>
+</svg>

--- a/src/clients/ReserveSubgraph.ts
+++ b/src/clients/ReserveSubgraph.ts
@@ -18,7 +18,7 @@ export const reserveQuery = `
     totalDeposit
     lTokenUserBalanceCount
     dTokenUserBalanceCount
-    deposit {
+    deposit(first: 1000) {
       id
     }
     incentivePool {

--- a/src/components/AssetList/AssetItem.tsx
+++ b/src/components/AssetList/AssetItem.tsx
@@ -6,7 +6,7 @@ import ReserveData from 'src/core/data/reserves';
 import { IAssetBond } from 'src/core/types/reserveSubgraph';
 import Skeleton from 'react-loading-skeleton';
 
-const LazyImage = lazy(() => import('src/utiles/lazyImage'));
+const UndefinedImage = lazy(() => import('src/utiles/undefinedImage'));
 
 const AssetItem: FunctionComponent<{
   abToken: IAssetBond;
@@ -33,7 +33,7 @@ const AssetItem: FunctionComponent<{
     }
     try {
       const response = await Slate.fetctABTokenIpfs(abToken.ipfsHash || '');
-      setImage(`${baseUrl}/${response.data.images[0]?.hash}`)
+      setImage(`${baseUrl}/${response.data.images[0]?.hash}`);
     } catch (error) {
       console.error(error);
     }
@@ -47,7 +47,7 @@ const AssetItem: FunctionComponent<{
     <div className="component__loan-list" style={style} onClick={onClick}>
       <div className="component__loan-list__image">
         <Suspense fallback={<Skeleton width={'100%'} height={'100%'} />}>
-          <LazyImage src={image} name={`csp_image`} />
+          <UndefinedImage image={image} />
         </Suspense>
       </div>
       <div className="component__loan-list__data">

--- a/src/components/Deposit/TokenTable.tsx
+++ b/src/components/Deposit/TokenTable.tsx
@@ -126,7 +126,7 @@ const TokenTable: React.FC<Props> = ({
           className="deposit__table__header"
           style={{ cursor: 'pointer' }}
           onClick={() => {
-            navigate(`/${lng}/deposits/${balance.tokenName}`);
+            navigate(`/${lng}/deposit/${balance.tokenName}`);
           }}>
           <div className="deposit__table__header__token-info">
             <LazyImage src={tokenInfo.image} name="Token icon" />

--- a/src/components/Deposit/TokenTable.tsx
+++ b/src/components/Deposit/TokenTable.tsx
@@ -79,10 +79,14 @@ const TokenTable: React.FC<Props> = ({
     },
   );
   const assetBondTokensBackedByEstate = reserveData?.id
-    ? reserveData.assetBondTokens.filter((ab) => {
-        const parsedId = parseTokenId(ab.id);
-        return CollateralCategory.Others !== parsedId.collateralCategory;
-      })
+    ? reserveData.assetBondTokens
+        .filter((ab) => {
+          const parsedId = parseTokenId(ab.id);
+          return CollateralCategory.Others !== parsedId.collateralCategory;
+        })
+        .sort((a, b) => {
+          return b.loanStartTimestamp! - a.loanStartTimestamp! >= 0 ? 1 : -1;
+        })
     : undefined;
 
   const isWrongMainnet = isWrongNetwork(getMainnetType, currentChain?.name);
@@ -341,15 +345,10 @@ const TokenTable: React.FC<Props> = ({
                     assetBondTokens={
                       // Tricky : javascript의 sort는 mutuable이라 아래와 같이 복사 후 진행해야한다.
                       assetBondTokensBackedByEstate
-                        ? [...assetBondTokensBackedByEstate]
-                            .sort((a, b) => {
-                              return b.loanStartTimestamp! -
-                                a.loanStartTimestamp! >=
-                                0
-                                ? 1
-                                : -1;
-                            })
-                            .slice(0, mediaQuery === MediaQuery.PC ? 3 : 2)
+                        ? [...assetBondTokensBackedByEstate].slice(
+                            0,
+                            mediaQuery === MediaQuery.PC ? 3 : 2,
+                          )
                         : undefined
                     }
                   />

--- a/src/components/Governance/OffchainContainer.tsx
+++ b/src/components/Governance/OffchainContainer.tsx
@@ -13,7 +13,7 @@ interface Props {
 
 const OffChainContainer: React.FC<Props> = ({ data }) => {
   const { t } = useTranslation();
-  console.log(data.images);
+
   return (
     <div
       className="governance__validation__assets governance__asset"

--- a/src/components/Governance/OffchainContainer.tsx
+++ b/src/components/Governance/OffchainContainer.tsx
@@ -5,8 +5,7 @@ import PageEventType from 'src/enums/PageEventType';
 import ButtonEventType from 'src/enums/ButtonEventType';
 import { useTranslation } from 'react-i18next';
 import FallbackSkeleton from 'src/utiles/FallbackSkeleton';
-
-const LazyImage = lazy(() => import('src/utiles/lazyImage'));
+import UnKnownImage from 'src/assets/images/undefined_image.svg';
 
 interface Props {
   data: INapData;
@@ -14,7 +13,7 @@ interface Props {
 
 const OffChainContainer: React.FC<Props> = ({ data }) => {
   const { t } = useTranslation();
-
+  console.log(data.images);
   return (
     <div
       className="governance__validation__assets governance__asset"
@@ -27,7 +26,13 @@ const OffChainContainer: React.FC<Props> = ({ data }) => {
       }}>
       <Suspense fallback={<FallbackSkeleton width={'100%'} height={300} />}>
         <div>
-          <LazyImage src={`https://${data.images}`} name="container-images" />
+          <img
+            src={`https://${data.images}`}
+            alt="vote image"
+            onError={(e: any) => {
+              e.target.src = UnKnownImage;
+            }}
+          />
         </div>
         <div>
           <div className="governance__asset__nap">

--- a/src/components/Governance/OnchainContainer.tsx
+++ b/src/components/Governance/OnchainContainer.tsx
@@ -6,12 +6,11 @@ import ButtonEventType from 'src/enums/ButtonEventType';
 import { useTranslation } from 'react-i18next';
 import { TopicList } from 'src/clients/OffChainTopic';
 import { utils } from 'ethers';
+import UnKnownImage from 'src/assets/images/undefined_image.svg';
 
 import TempAssets from 'src/assets/images/governance/temp_assets.svg';
 import FallbackSkeleton from 'src/utiles/FallbackSkeleton';
 import MainnetType from 'src/enums/MainnetType';
-
-const LazyImage = lazy(() => import('src/utiles/lazyImage'));
 
 interface Props {
   data: IProposals;
@@ -50,13 +49,16 @@ const OnChainContainer: React.FC<Props> = ({
       }}>
       <Suspense fallback={<FallbackSkeleton width={'100%'} height={300} />}>
         <div>
-          <LazyImage
-            name="Asset-image"
+          <img
             src={
               offChainNapData && offChainData?.length !== 0
                 ? 'https://' + offChainData![0].images
                 : TempAssets
             }
+            alt="vote image"
+            onError={(e: any) => {
+              e.target.src = UnKnownImage;
+            }}
           />
         </div>
         <div>

--- a/src/components/Governance/index.tsx
+++ b/src/components/Governance/index.tsx
@@ -56,10 +56,14 @@ const Governance = (): JSX.Element => {
   const { value: mediaQuery } = useMediaQueryType();
   const defaultShowingLoanData = mediaQuery === MediaQuery.Mobile ? 8 : 9;
   const [isAssetList, setIsAssetList] = useState(false);
-  const assetBondTokensBackedByEstate = assetBondTokens.filter((product) => {
-    const parsedId = parseTokenId(product.id);
-    return CollateralCategory.Others !== parsedId.collateralCategory;
-  });
+  const assetBondTokensBackedByEstate = assetBondTokens
+    .filter((product) => {
+      const parsedId = parseTokenId(product.id);
+      return CollateralCategory.Others !== parsedId.collateralCategory;
+    })
+    .sort((a, b) => {
+      return b.loanStartTimestamp! - a.loanStartTimestamp! >= 0 ? 1 : -1;
+    });
 
   const { data: onChainData, isValidating: onChainLoading } = useSWR(
     onChainQuery,
@@ -282,19 +286,10 @@ const Governance = (): JSX.Element => {
                   <AssetList
                     prevRoute={'governance'}
                     assetBondTokens={
-                      /* Tricky : javascript의 sort는 mutuable이라 아래와 같이 복사 후 진행해야한다. */
-                      [
-                        ...((assetBondTokensBackedByEstate as IAssetBond[]) ||
-                          []),
-                      ]
-                        .slice(0, pageNumber * defaultShowingLoanData)
-                        .sort((a, b) => {
-                          return b.loanStartTimestamp! -
-                            a.loanStartTimestamp! >=
-                            0
-                            ? 1
-                            : -1;
-                        }) || []
+                      [...(assetBondTokensBackedByEstate || [])].slice(
+                        0,
+                        pageNumber * defaultShowingLoanData,
+                      ) || []
                     }
                   />
                   {assetBondTokensBackedByEstate &&

--- a/src/components/LiquidiryDetails/Loan.tsx
+++ b/src/components/LiquidiryDetails/Loan.tsx
@@ -33,13 +33,17 @@ const Loan: FunctionComponent<{ id: string }> = ({ id }) => {
     ),
   );
 
-  const assetBondTokensBackedByEstate = assetBondTokens.filter((product) => {
-    const parsedId = parseTokenId(product.id);
-    return (
-      CollateralCategory.Others !== parsedId.collateralCategory &&
-      product.reserve.id === id
-    );
-  });
+  const assetBondTokensBackedByEstate = assetBondTokens
+    .filter((product) => {
+      const parsedId = parseTokenId(product.id);
+      return (
+        CollateralCategory.Others !== parsedId.collateralCategory &&
+        product.reserve.id === id
+      );
+    })
+    .sort((a, b) => {
+      return b.loanStartTimestamp! - a.loanStartTimestamp! >= 0 ? 1 : -1;
+    });
 
   const viewMoreHandler = useCallback(() => {
     setPageNumber((prev) => prev + 1);
@@ -65,21 +69,10 @@ const Loan: FunctionComponent<{ id: string }> = ({ id }) => {
             <AssetList
               assetBondTokens={
                 /* Tricky : javascript의 sort는 mutuable이라 아래와 같이 복사 후 진행해야한다. */
-                [...(assetBondTokensBackedByEstate || [])]
-                  .slice(0, pageNumber * defaultShowingLoanData)
-                  .sort((a, b) => {
-                    if (sortMode) {
-                      return BigNumber.from(b.principal).gte(
-                        BigNumber.from(a.principal),
-                      )
-                        ? 1
-                        : -1;
-                    } else {
-                      return b.loanStartTimestamp! - a.loanStartTimestamp! >= 0
-                        ? 1
-                        : -1;
-                    }
-                  }) || []
+                [...(assetBondTokensBackedByEstate || [])].slice(
+                  0,
+                  pageNumber * defaultShowingLoanData,
+                ) || []
               }
             />
             {assetBondTokensBackedByEstate.length &&

--- a/src/components/Portfolio/index.tsx
+++ b/src/components/Portfolio/index.tsx
@@ -188,13 +188,16 @@ const PortfolioDetail: FunctionComponent = () => {
                       style={{
                         cursor: 'pointer',
                       }}>
-                      <LazyImage
+                      <img
                         style={{
                           width: 538.5,
                           height: 526,
                         }}
                         src={contractImage[3]?.link || TempAssets}
-                        name={contractImage[3]?.link || TempAssets}
+                        alt="Asset Image"
+                        onError={(e: any) => {
+                          e.target.src = TempAssets;
+                        }}
                       />
                     </a>
                   </Suspense>

--- a/src/components/Portfolio/index.tsx
+++ b/src/components/Portfolio/index.tsx
@@ -26,6 +26,7 @@ import useReserveData from 'src/hooks/useReserveData';
 import { IAssetBond } from 'src/core/types/reserveSubgraph';
 import Skeleton from 'react-loading-skeleton';
 import useNavigator from 'src/hooks/useNavigator';
+import UnKnownImage from 'src/assets/images/undefined_image.svg';
 
 const LazyImage = lazy(() => import('src/utiles/lazyImage'));
 
@@ -196,7 +197,7 @@ const PortfolioDetail: FunctionComponent = () => {
                         src={contractImage[3]?.link || TempAssets}
                         alt="Asset Image"
                         onError={(e: any) => {
-                          e.target.src = TempAssets;
+                          e.target.src = UnKnownImage;
                         }}
                       />
                     </a>

--- a/src/utiles/undefinedImage.tsx
+++ b/src/utiles/undefinedImage.tsx
@@ -1,0 +1,42 @@
+import { lazy } from 'react';
+import UnKnownImage from 'src/assets/images/undefined_image.svg';
+import MediaQuery from 'src/enums/MediaQuery';
+import useMediaQueryType from 'src/hooks/useMediaQueryType';
+
+const LazyImage = lazy(() => import('src/utiles/lazyImage'));
+
+const UndefinedImage: React.FC<{ image: string }> = ({ image }) => {
+  const { value: mediaQuery } = useMediaQueryType();
+
+  return image ? (
+    <LazyImage src={image} name={`csp_image`} />
+  ) : (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '100%',
+      }}>
+      <LazyImage
+        src={UnKnownImage}
+        name="Asset image is temporarily unavailable"
+        style={{
+          width: mediaQuery === MediaQuery.PC ? 'auto' : 50,
+          marginBottom: 20,
+        }}
+      />
+      <p
+        style={{
+          textAlign: 'center',
+          color: '#888',
+          fontSize: mediaQuery === MediaQuery.PC ? 16 : 10,
+        }}>
+        Asset image is temporarily unavailable
+      </p>
+    </div>
+  );
+};
+
+export default UndefinedImage;


### PR DESCRIPTION
해당 브랜치에서 작업된 내용은 아래와 같습니다.

* deposits 으로 연결된 링크들을 정상적으로 수정했습니다.
* 더보기 버튼을 클릭했을 때마다 배열이 sort되는 이슈를 해결했습니다.
* 예치자 수 버그를 해결했습니다.

* slate에서 불러오는 이미지들에 예외처리를 추가했습니다.

1. deposit 에서 사진을 찾을 수 없을 때, 아래와 같이 이미지를 이용할 수 없다고 출력합니다.
![스크린샷 2022-04-12 오전 12 25 45](https://user-images.githubusercontent.com/59865307/162773548-d8b9f98a-a276-4c69-9b34-e7ba2178b45c.png)

2. governance 및및 portfolio details에서 이미지를 불러올 수 없을 때, 아래와 같이 엑박 이미지로 변경해서 출력합니다.
![스크린샷 2022-04-12 오전 12 26 40](https://user-images.githubusercontent.com/59865307/162773856-e52ecd85-2b20-46dc-a3e6-351768586d95.png)
![스크린샷 2022-04-12 오전 12 29 16](https://user-images.githubusercontent.com/59865307/162774785-60005e21-4463-4527-98e0-0328fee1a5ed.png)



