### PR TITLE
Fix/staking word

### DIFF
--- a/src/components/LpStaking/index.tsx
+++ b/src/components/LpStaking/index.tsx
@@ -369,7 +369,7 @@ function LPStaking(): JSX.Element {
                           <p>{t('staking.elfi.total_amount')}</p>
                           <h2>
                             {parseFloat(formatEther(totalPrincipal))}{' '}
-                            {rewardToken}
+                            {Token.UNI}
                           </h2>
                         </div>
                       </div>

--- a/src/components/Staking/modal/StakingModalV2.tsx
+++ b/src/components/Staking/modal/StakingModalV2.tsx
@@ -143,13 +143,15 @@ const StakingModalV2: React.FunctionComponent<{
                       return;
                     }
                     setAmount({
-                      value: Math.floor(
-                        parseFloat(
-                          utils.formatEther(
-                            stakingMode ? balance : stakedBalance,
-                          ),
-                        ),
-                      ).toFixed(8),
+                      value: (
+                        Math.floor(
+                          parseFloat(
+                            utils.formatEther(
+                              stakingMode ? balance : stakedBalance,
+                            ),
+                          ) * 10000000,
+                        ) / 10000000
+                      ).toString(),
                       max: true,
                     });
                   }}>


### PR DESCRIPTION
보상 토큰의 이름을 UNI-V2 로 변경했고, 스테이킹 모달창에서 max 버튼 클릭시 수식을 변경해서 소숫점 자리도 출력하도록 작성했습니다.
해당 브랜치에서 그 외 다른 기능은 없습니다.