### PR TITLE
Fix/disconnect loading issue

### DIFF
--- a/src/components/Staking/hooks/useStakingFetchRoundDataV2.ts
+++ b/src/components/Staking/hooks/useStakingFetchRoundDataV2.ts
@@ -84,10 +84,8 @@ const useStakingFetchRoundDataV2 = (
           ),
         );
       } else {
-        if (!priceData) return;
         data.push(stakedData(priceData));
       }
-
       setroundData(data);
       setLoading(false);
       setError(false);
@@ -104,11 +102,12 @@ const useStakingFetchRoundDataV2 = (
 
   useEffect(() => {
     fetchRoundData(account);
-  }, [account, poolApr, getMainnetType, stakingPool]);
+  }, [poolApr, stakingPool]);
 
   useEffect(() => {
     setLoading(true);
     setError(false);
+    fetchRoundData(account);
   }, [account, getMainnetType]);
 
   return { roundData, loading, error, fetchRoundData };

--- a/src/components/Staking/index.tsx
+++ b/src/components/Staking/index.tsx
@@ -363,7 +363,7 @@ const Staking: React.FunctionComponent<IProps> = ({ rewardToken }) => {
                       <div>
                         <h2>
                           {`${formatCommaSmall(
-                            roundData[0]?.accountPrincipal || '0',
+                            roundData[0]?.accountPrincipal || constants.Zero,
                           )}`}
                           <span className="token-amount bold">
                             {stakedToken}


### PR DESCRIPTION
지갑 연결을 해제할 때 스켈레톤이 무한으로 돌던 이슈를 해결했습니다.
원인을 확인해보니, 기존 fetchRoundData에서는 일단 실행하자마자 await Promise all을 불러온 뒤 response에 따라 if else로 나누고 있었는데, 
V2에서는 먼저 if account를 체크하고 account가 있을 때만 await이 동작하도록 바꿨었습니다. (굳이 모든 round data를 받아올 필요가 없어져서!)
그래서 account가 없어서 else로 빠질 때마다 await이 없기 때문에 useEffect 호출 순서가 꼬여버려서 setLoading(true)가 마지막에 호출되고 있었습니다.

일단 useEffect의 dependency를 바꿔놓고 테스트 해 보니 정상적으로 작동되는데, 로직에 문제는 없겠죠..? ㅠㅠ
