### PR TITLE
delete endedbalanace

### DIFF
--- a/src/components/LpStaking/index.tsx
+++ b/src/components/LpStaking/index.tsx
@@ -37,6 +37,7 @@ import {
 import StakingModalType from 'src/enums/StakingModalType';
 import Skeleton from 'react-loading-skeleton';
 import useUniswapV2Apr from 'src/hooks/useUniswapV2Apr';
+import ModalViewType from 'src/enums/ModalViewType';
 import LegacyStakingButton from '../LegacyStaking/LegacyStakingButton';
 import useStakingRoundDataV2 from '../Staking/hooks/useStakingRoundDataV2';
 import useStakingFetchRoundDataV2 from '../Staking/hooks/useStakingFetchRoundDataV2';
@@ -245,11 +246,6 @@ function LPStaking(): JSX.Element {
                   ? ethExpectedReward
                   : daiExpectedReward
               }
-              endedBalance={
-                (selectToken === Token.ELFI_ETH_LP
-                  ? ethRoundData[0]?.accountReward
-                  : daiRoundData[0]?.accountReward) || constants.Zero
-              }
               stakingBalance={
                 selectToken === Token.ELFI_ETH_LP
                   ? ethLoading
@@ -411,10 +407,10 @@ function LPStaking(): JSX.Element {
                                   if (!account || isWrongMainnet) {
                                     return;
                                   }
-                                  // ReactGA.modalview(
-                                  //   stakedToken +
-                                  //     ModalViewType.StakingOrUnstakingModal,
-                                  // );
+                                  ReactGA.modalview(
+                                    data[0] +
+                                      ModalViewType.StakingOrUnstakingModal,
+                                  );
                                   setToken(
                                     data[0] === 'ELFI-ETH LP'
                                       ? Token.ELFI_ETH_LP
@@ -469,9 +465,10 @@ function LPStaking(): JSX.Element {
                                   ) {
                                     return;
                                   }
-                                  // ReactGA.modalview(
-                                  //   stakedToken + ModalViewType.StakingIncentiveModal,
-                                  // );
+                                  ReactGA.modalview(
+                                    data[0] +
+                                      ModalViewType.StakingIncentiveModal,
+                                  );
                                   setToken(
                                     data[0] === 'ELFI-ETH LP'
                                       ? Token.ELFI_ETH_LP

--- a/src/components/LpStaking/index.tsx
+++ b/src/components/LpStaking/index.tsx
@@ -161,6 +161,30 @@ function LPStaking(): JSX.Element {
     };
   }, [document.body.clientHeight]);
 
+  const setExpectedReward = (token: Token) => {
+    return token === Token.ELFI_ETH_LP
+      ? setEthExpectedReward({
+          ...ethExpectedReward,
+          before: ethExpectedReward.value.isZero()
+            ? ethRoundData[0].accountReward
+            : ethExpectedReward.value,
+          value: calcExpectedReward(
+            ethRoundData[0],
+            rewardPerDayByToken(Token.ELFI_ETH_LP, getMainnetType),
+          ),
+        })
+      : setDaiExpectedReward({
+          ...daiExpectedReward,
+          before: daiExpectedReward.value.isZero()
+            ? daiRoundData[0].accountReward
+            : daiExpectedReward.value,
+          value: calcExpectedReward(
+            daiRoundData[0],
+            rewardPerDayByToken(Token.ELFI_DAI_LP, getMainnetType),
+          ),
+        });
+  };
+
   useEffect(() => {
     if (ethLoading || ethError) return;
 
@@ -262,11 +286,15 @@ function LPStaking(): JSX.Element {
               }
               closeHandler={() => {
                 setModalType('');
+                setExpectedReward(
+                  selectToken === Token.ELFI_ETH_LP
+                    ? Token.ELFI_ETH_LP
+                    : Token.ELFI_DAI_LP,
+                );
                 setTransactionWait(false);
               }}
               afterTx={() => {
-                account && daiFetchData(account);
-                ethFetchData(account);
+                account && (daiFetchData(account), ethFetchData(account));
               }}
               transactionModal={() => setTransactionModal(true)}
               transactionWait={transactionWait}
@@ -465,6 +493,11 @@ function LPStaking(): JSX.Element {
                                   ) {
                                     return;
                                   }
+                                  setExpectedReward(
+                                    data[0] === 'ELFI-ETH LP'
+                                      ? Token.ELFI_ETH_LP
+                                      : Token.ELFI_DAI_LP,
+                                  );
                                   ReactGA.modalview(
                                     data[0] +
                                       ModalViewType.StakingIncentiveModal,
@@ -474,6 +507,7 @@ function LPStaking(): JSX.Element {
                                       ? Token.ELFI_ETH_LP
                                       : Token.ELFI_DAI_LP,
                                   );
+
                                   setModalValue(expectedReward.value);
                                   setModalType(StakingModalType.Claim);
                                 }}>

--- a/src/components/Staking/index.tsx
+++ b/src/components/Staking/index.tsx
@@ -195,7 +195,6 @@ const Staking: React.FunctionComponent<IProps> = ({ rewardToken }) => {
               stakedToken={Token.ELFI}
               token={Token.ELFI}
               balance={expectedReward}
-              endedBalance={roundData[0]?.accountReward || constants.Zero}
               stakingBalance={
                 loading ? constants.Zero : roundData[0]?.accountPrincipal
               }

--- a/src/components/Staking/modal/ClaimStakingRewardModalV2.tsx
+++ b/src/components/Staking/modal/ClaimStakingRewardModalV2.tsx
@@ -27,7 +27,6 @@ const ClaimStakingRewardModalV2: FunctionComponent<{
     before: BigNumber;
     value: BigNumber;
   };
-  endedBalance: BigNumber;
   stakingBalance: BigNumber;
   currentRound: RoundData;
   visible: boolean;
@@ -42,7 +41,6 @@ const ClaimStakingRewardModalV2: FunctionComponent<{
   stakingBalance,
   token,
   balance,
-  endedBalance,
   closeHandler,
   afterTx,
   transactionModal,
@@ -79,28 +77,26 @@ const ClaimStakingRewardModalV2: FunctionComponent<{
                         ? 30
                         : 60,
                   }}>
-                  {!endedBalance?.isZero()
-                    ? formatCommaSmall(endedBalance)
-                    : balance && (
-                        <CountUp
-                          className={`spoqa__bold colored ${
-                            token === Token.ELFI ? 'EL' : 'ELFI'
-                          }`}
-                          start={parseFloat(formatEther(balance.before))}
-                          end={parseFloat(
-                            formatEther(
-                              balance.before.isZero()
-                                ? currentRound.accountReward
-                                : balance.value,
-                            ),
-                          )}
-                          formattingFn={(number) => {
-                            return formatSixFracionDigit(number);
-                          }}
-                          decimals={6}
-                          duration={1}
-                        />
+                  {balance && (
+                    <CountUp
+                      className={`spoqa__bold colored ${
+                        token === Token.ELFI ? 'EL' : 'ELFI'
+                      }`}
+                      start={parseFloat(formatEther(balance.before))}
+                      end={parseFloat(
+                        formatEther(
+                          balance.before.isZero()
+                            ? currentRound.accountReward
+                            : balance.value,
+                        ),
                       )}
+                      formattingFn={(number) => {
+                        return formatSixFracionDigit(number);
+                      }}
+                      decimals={6}
+                      duration={1}
+                    />
+                  )}
                 </p>
               </div>
             </>
@@ -109,7 +105,7 @@ const ClaimStakingRewardModalV2: FunctionComponent<{
             className={`modal__button ${transactionWait ? 'disable' : ''}`}
             onClick={() => {
               transactionWait ? undefined : setTransactionWait();
-              if (!account) return;
+              if (!account || !balance) return;
 
               const emitter = buildEventEmitter(
                 ModalViewType.StakingIncentiveModal,
@@ -120,9 +116,7 @@ const ClaimStakingRewardModalV2: FunctionComponent<{
                   address: account,
                   stakingType: stakedToken,
                   stakingAmount: utils.formatEther(stakingBalance),
-                  incentiveAmount: utils.formatEther(
-                    balance?.value || endedBalance,
-                  ),
+                  incentiveAmount: utils.formatEther(balance.value),
                 }),
               );
 


### PR DESCRIPTION
우선 utils > stakingReward.ts 에서 rewardPerDayByToken의 일일 토큰 보상량을 수정하는 작업을 했었으나, 버그가 해결되지 않았었습니다.
코드를 조금 더 분석해보니, 스테이킹 보상 수량에서는 setExpectedReward로 일일 토큰 보상량을 계산한 값이 출력되고 있었는데 정작 모달창에서는 endedBalance라는 값을 체크해서 formatCommaSmall(endedBalance)을 countup expectedReward대신 출력하고 있었습니다. (확인해보니, 라운드가 종료될 때 roundData.accountReward 를 가져오도록 하는 인자값이었습니다)
더 이상 사용하지는 않을것 같아서 endedBalance가 출력되고 있던것을 지워둔 뒤 expectedReward가 나오도록 변경했습니다.

