### PR TITLE
Fix/wave background

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -3,16 +3,28 @@ import Telegram from 'src/assets/images/footer/telegram.svg';
 import Github from 'src/assets/images/footer/github.svg';
 import Discord from 'src/assets/images/footer/discord.svg';
 import LazyImage from 'src/utiles/lazyImage';
-import { lazy, Suspense } from 'react';
+import { lazy, Suspense, useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
 
 const LanguageConverter = lazy(
   () => import('src/components/Footer/LanguageConverter'),
 );
 
 const Footer = (): JSX.Element => {
+  const location = useLocation();
+  const currentPage = useMemo(() => {
+    return location.pathname.split('/')[3] === 'EL';
+  }, [location]);
+
   return (
     <Suspense fallback={null}>
-      <footer className="footer">
+      <footer
+        className="footer"
+        style={{
+          backgroundColor: currentPage
+            ? 'rgba(247, 251, 255, 1)'
+            : 'transparent',
+        }}>
         <div>
           <div className="footer__right-container">
             <LanguageConverter />

--- a/src/components/LegacyStaking/LegacyLpstaking.tsx
+++ b/src/components/LegacyStaking/LegacyLpstaking.tsx
@@ -43,6 +43,7 @@ import RecentActivityType from 'src/enums/RecentActivityType';
 import toOrdinalNumber from 'src/utiles/toOrdinalNumber';
 import usePricePerLiquidity from 'src/hooks/usePricePerLiquidity';
 import stakerABI from 'src/core/abi/StakerABI.json';
+import { waveMaximumHeight } from 'src/core/data/waveHeight';
 
 const LegacyStaking: React.FC = () => {
   const { account, library } = useWeb3React();
@@ -220,7 +221,7 @@ const LegacyStaking: React.FC = () => {
         ? canvas.height / 3 / dpr
         : 90;
     const browserWidth = canvas.width / dpr + 40;
-    const browserHeight = 4096;
+    const browserHeight = waveMaximumHeight;
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
     ctx.scale(dpr, dpr);

--- a/src/components/LegacyStaking/LegacyLpstaking.tsx
+++ b/src/components/LegacyStaking/LegacyLpstaking.tsx
@@ -220,7 +220,7 @@ const LegacyStaking: React.FC = () => {
         ? canvas.height / 3 / dpr
         : 90;
     const browserWidth = canvas.width / dpr + 40;
-    const browserHeight = canvas.height;
+    const browserHeight = 4096;
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
     ctx.scale(dpr, dpr);

--- a/src/components/LegacyStaking/index.tsx
+++ b/src/components/LegacyStaking/index.tsx
@@ -107,7 +107,7 @@ const LegacyStaking: React.FC = () => {
         ? canvas.height / 3 / dpr
         : 90;
     const browserWidth = canvas.width / dpr + 40;
-    const browserHeight = canvas.height;
+    const browserHeight = 4096;
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
     ctx.scale(dpr, dpr);

--- a/src/components/LegacyStaking/index.tsx
+++ b/src/components/LegacyStaking/index.tsx
@@ -24,6 +24,7 @@ import FinishedStaking from 'src/components/Staking/FinishedStaking';
 import { constants, ethers, utils } from 'ethers';
 import StakingModalType from 'src/enums/StakingModalType';
 import Skeleton from 'react-loading-skeleton';
+import { waveMaximumHeight } from 'src/core/data/waveHeight';
 
 const ClaimStakingRewardModal = lazy(
   () => import('src/components/Modal/ClaimStakingRewardModal'),
@@ -107,7 +108,7 @@ const LegacyStaking: React.FC = () => {
         ? canvas.height / 3 / dpr
         : 90;
     const browserWidth = canvas.width / dpr + 40;
-    const browserHeight = 4096;
+    const browserHeight = waveMaximumHeight;
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
     ctx.scale(dpr, dpr);

--- a/src/components/Staking/ElStaking.tsx
+++ b/src/components/Staking/ElStaking.tsx
@@ -4,13 +4,11 @@ import TokenColors from 'src/enums/TokenColors';
 import useMediaQueryType from 'src/hooks/useMediaQueryType';
 import DrawWave from 'src/utiles/drawWave';
 import { useTranslation, Trans } from 'react-i18next';
-import { useParams } from 'react-router-dom';
 
 const ElStaking: React.FC = () => {
   const { t } = useTranslation();
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const headerRef = useRef<HTMLDivElement>(null);
-  const { lng } = useParams<{ lng: string }>();
 
   const { value: mediaQuery } = useMediaQueryType();
 
@@ -43,7 +41,7 @@ const ElStaking: React.FC = () => {
   };
 
   useEffect(() => {
-    draw();
+    setTimeout(() => draw(), 0);
     window.addEventListener('scroll', () => draw());
     window.addEventListener('resize', () => draw());
 
@@ -65,6 +63,7 @@ const ElStaking: React.FC = () => {
           zIndex: -1,
         }}
       />
+      <section ref={headerRef} style={{ position: 'absolute', bottom: 0 }} />
       <div className="staking__el__content">
         <h2>{t('staking.el.title')}</h2>
         <p>
@@ -73,7 +72,6 @@ const ElStaking: React.FC = () => {
         <div onClick={() => window.open(`https://gov.elysia.land/`)}>
           <p>{t('staking.el.button')}</p>
         </div>
-        <section ref={headerRef} />
       </div>
     </section>
   );

--- a/src/components/Staking/ElStaking.tsx
+++ b/src/components/Staking/ElStaking.tsx
@@ -42,7 +42,7 @@ const ElStaking: React.FC = () => {
   };
 
   useEffect(() => {
-    setTimeout(() => draw(), 0);
+    draw();
     window.addEventListener('scroll', () => draw());
     window.addEventListener('resize', () => draw());
 

--- a/src/components/Staking/ElStaking.tsx
+++ b/src/components/Staking/ElStaking.tsx
@@ -25,7 +25,7 @@ const ElStaking: React.FC = () => {
         ? canvas.height / 2 / dpr
         : 90;
     const browserWidth = canvas.width / dpr + 40;
-    const browserHeight = canvas.height;
+    const browserHeight = 4320;
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
     ctx.scale(dpr, dpr);
@@ -63,7 +63,7 @@ const ElStaking: React.FC = () => {
           zIndex: -1,
         }}
       />
-      <section ref={headerRef} style={{ position: 'absolute', bottom: 0 }} />
+      <section ref={headerRef} />
       <div className="staking__el__content">
         <h2>{t('staking.el.title')}</h2>
         <p>

--- a/src/components/Staking/ElStaking.tsx
+++ b/src/components/Staking/ElStaking.tsx
@@ -4,6 +4,7 @@ import TokenColors from 'src/enums/TokenColors';
 import useMediaQueryType from 'src/hooks/useMediaQueryType';
 import DrawWave from 'src/utiles/drawWave';
 import { useTranslation, Trans } from 'react-i18next';
+import { waveMaximumHeight } from 'src/core/data/waveHeight';
 
 const ElStaking: React.FC = () => {
   const { t } = useTranslation();
@@ -25,7 +26,7 @@ const ElStaking: React.FC = () => {
         ? canvas.height / 2 / dpr
         : 90;
     const browserWidth = canvas.width / dpr + 40;
-    const browserHeight = 4320;
+    const browserHeight = waveMaximumHeight;
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
     ctx.scale(dpr, dpr);

--- a/src/core/data/waveHeight.ts
+++ b/src/core/data/waveHeight.ts
@@ -1,0 +1,9 @@
+/*
+  why 4320?
+  This value is the vertical value of UHD, which is the maximum resolution of an 8K monitor.
+  The screen to which this value is applied has a fixed height of 100% anyway, 
+  so it doesn't matter if the constant value is higher, 
+  but first, we took the vertical value of the currently highest monitor resolution as a standard.
+*/
+
+export const waveMaximumHeight = 4320;

--- a/src/stylesheet/public.scss
+++ b/src/stylesheet/public.scss
@@ -3009,6 +3009,7 @@ input[type='number'] {
 
     &__el {
       height: calc(100vh - 322px);
+      min-height: 100%;
       margin: 0 auto;
       width: 1190px;
       &__content {


### PR DESCRIPTION
현재 엘리파이 EL 스테이킹 페이지에서 아래 사진처럼 이미지가 잘리거나 선이 잘못 그려지는 이슈가 있었습니다.
확인해보니, 해당 페이지들은 css에서 height를 calc로 계산해서 그려주고 있었는데, 계산이 완료되기 전에 height 값을 ref로 가져와서 계산할 때가 있어서 오류가 발생하고 있었습니다.
어차피 디자인 상 height 값을 따로 계산할 필요가 없기때문에 8K 기준 height 최대값인 4096을 상수로 넘겨주고, footer에 색상을 추가했습니다.
해당 브랜치로 픽스된 페이지는 EL, legacy ELFI, legacy LP 페이지 뿐이며, 그 외 다른 기능은 없습니다.