### PR TITLE
Fix/lp usd amount

### DIFF
--- a/src/components/Staking/CurrentStakingAmount.tsx
+++ b/src/components/Staking/CurrentStakingAmount.tsx
@@ -1,6 +1,7 @@
 import { BigNumber, constants } from 'ethers';
 import { formatEther } from 'ethers/lib/utils';
 import Skeleton from 'react-loading-skeleton';
+import { formatSixFracionDigit } from 'src/utiles/formatters';
 
 const CurrentStakingAmount: React.FC<{
   tokenUsdPrice: number;
@@ -13,9 +14,9 @@ const CurrentStakingAmount: React.FC<{
     <span>0</span>
   ) : (
     <span>
-      {(
-        parseFloat(formatEther(roundData || constants.Zero)) * tokenUsdPrice
-      ).toFixed(6)}
+      {formatSixFracionDigit(
+        parseFloat(formatEther(roundData || constants.Zero)) * tokenUsdPrice,
+      )}
     </span>
   );
 };

--- a/src/hooks/useLpPrice.ts
+++ b/src/hooks/useLpPrice.ts
@@ -46,9 +46,16 @@ const useLpPrice = (): {
       parseFloat(utils.formatEther(v2LPPoolElfi[1])) * priceData.elfiPrice +
       parseFloat(utils.formatEther(balances.v2LPPoolDai)) * priceData.daiPrice;
 
+    const ethPerTokenPrice =
+      stakedTokenElfiEthPrice /
+      parseFloat(utils.formatEther(balances.ethTotalSupply));
+    const daiPerTokenPrice =
+      stakedTokenElfiDaiPrice /
+      parseFloat(utils.formatEther(balances.daiTotalSupply));
+
     setLpPriceState({
-      ethLpPrice: stakedTokenElfiEthPrice,
-      daiLpPrice: stakedTokenElfiDaiPrice,
+      ethLpPrice: ethPerTokenPrice,
+      daiLpPrice: daiPerTokenPrice,
       loading: false,
     });
   }, [priceData, balances, v2LPPoolElfi]);


### PR DESCRIPTION
LP 스테이킹 토큰이 잘 못 계산되고 있던 이슈를 해결했습니다.

토큰 1개당 가치 * 유저가 보유중인 토큰 으로 계산 되어야 하는데 balances.totalSupply로 나누는 작업이 누락되서 머니풀 전체의 가치 * 유저의 토큰 보유량 으로 출력되던 이슈가 있었습니다..

이 브랜치에서는 해당 오류를 수정한 뒤, formatter를 추가해 페이지의 가독성을 향상시켰습니다.