### PR TITLE
Feat/disable legacy incentive

### DIFF
--- a/src/components/Deposit/TableBodyAmount.tsx
+++ b/src/components/Deposit/TableBodyAmount.tsx
@@ -9,7 +9,7 @@ const TableBodyAmount: React.FunctionComponent<{
   buttonContent: string;
   value: string | JSX.Element;
   tokenName: string;
-  moneyPoolTime?: string;
+  rewardUSDAmount?: JSX.Element;
   walletBalance?: string;
   loading: boolean;
 }> = ({
@@ -18,7 +18,7 @@ const TableBodyAmount: React.FunctionComponent<{
   buttonContent,
   value,
   tokenName,
-  moneyPoolTime,
+  rewardUSDAmount,
   walletBalance,
   loading,
 }) => {
@@ -44,13 +44,13 @@ const TableBodyAmount: React.FunctionComponent<{
           {loading ? (
             <Skeleton width={100} />
           ) : (
-            <p>
+            <p className={rewardUSDAmount ? 'equal_amount' : ''}>
               {walletBalance
                 ? `${t('dashboard.wallet_balance')} : ` +
                   walletBalance +
                   ' ' +
                   tokenName
-                : moneyPoolTime}
+                : rewardUSDAmount}
             </p>
           )}
         </div>
@@ -70,13 +70,13 @@ const TableBodyAmount: React.FunctionComponent<{
           {loading ? (
             <Skeleton width={50} />
           ) : (
-            <p>
+            <p className={rewardUSDAmount ? 'equal_amount' : ''}>
               {walletBalance
                 ? `${t('dashboard.wallet_balance')} : ` +
                   walletBalance +
                   ' ' +
                   tokenName
-                : moneyPoolTime}
+                : rewardUSDAmount}
             </p>
           )}
         </div>

--- a/src/components/Deposit/TableBodyEventReward.tsx
+++ b/src/components/Deposit/TableBodyEventReward.tsx
@@ -38,9 +38,9 @@ const TableBodyEventReward: FunctionComponent<Props> = ({
         <div className="deposit__table__body__event-box">
           <div className="deposit__table__body__event-box__content">
             <div>
-              <div className={`bold ${tokenName}`}>
-                <Trans>{t('dashboard.deposit_add_reward_event')}</Trans>
-              </div>
+              <h2 className={`bold ${tokenName}`}>
+                {t('dashboard.deposit_add_reward_event')}
+              </h2>
               <div
                 onClick={buttonEvent}
                 className="deposit__table__body__amount__button event-button">
@@ -82,9 +82,9 @@ const TableBodyEventReward: FunctionComponent<Props> = ({
         <div className="deposit__table__body__event-box">
           <div className="deposit__table__body__event-box__content">
             <div>
-              <div className={`bold ${tokenName}`}>
-                <Trans>{t('dashboard.deposit_add_reward_event')}</Trans>
-              </div>
+              <h2 className={`bold ${tokenName}`}>
+                {t('dashboard.deposit_add_reward_event')}
+              </h2>
               <div>
                 <div className="bold">
                   {' '}

--- a/src/components/Deposit/TokenTable.tsx
+++ b/src/components/Deposit/TokenTable.tsx
@@ -210,7 +210,7 @@ const TokenTable: React.FC<Props> = ({
                   setIncentiveModalVisible();
                   setModalNumber();
                   modalview();
-                  setRound(1);
+                  setRound(2);
                 }}
                 buttonContent={t('dashboard.claim_reward')}
                 value={
@@ -221,10 +221,12 @@ const TokenTable: React.FC<Props> = ({
                       <CountUp
                         className="bold amounts"
                         start={parseFloat(
-                          formatEther(balance.expectedIncentiveBefore),
+                          formatEther(
+                            balance.expectedAdditionalIncentiveBefore,
+                          ),
                         )}
                         end={parseFloat(
-                          formatEther(balance.expectedIncentiveAfter),
+                          formatEther(balance.expectedAdditionalIncentiveAfter),
                         )}
                         formattingFn={(number) => {
                           return formatSixFracionDigit(number);
@@ -236,15 +238,6 @@ const TokenTable: React.FC<Props> = ({
                   ) : (
                     '-'
                   )
-                }
-                moneyPoolTime={
-                  getMainnetType === MainnetType.Ethereum
-                    ? `${moment(daiMoneyPoolTime[0].startedAt).format(
-                        'YYYY.MM.DD',
-                      )} ~ ${moment(daiMoneyPoolTime[0].endedAt).format(
-                        'YYYY.MM.DD',
-                      )} KST`
-                    : undefined
                 }
                 tokenName={'ELFI'}
                 loading={account ? loading : false}
@@ -292,29 +285,33 @@ const TokenTable: React.FC<Props> = ({
                 </div>
               </div>
             )
-          ) : (
+          ) : balance.expectedIncentiveBefore.gt(0) ? (
             <div className="deposit__table__body__event-box">
               <TableBodyEventReward
-                moneyPoolTime={`${moment(daiMoneyPoolTime[1].startedAt).format(
+                moneyPoolTime={`${moment(daiMoneyPoolTime[0].startedAt).format(
                   'YYYY.MM.DD',
-                )} KST ~ `}
+                )} ~ ${moment(daiMoneyPoolTime[0].endedAt).format(
+                  'YYYY.MM.DD',
+                )} KST`}
                 expectedAdditionalIncentiveBefore={
-                  balance.expectedAdditionalIncentiveBefore
+                  balance.expectedIncentiveBefore
                 }
                 expectedAdditionalIncentiveAfter={
-                  balance.expectedAdditionalIncentiveAfter
+                  balance.expectedIncentiveAfter
                 }
                 buttonEvent={(e) => {
                   e.preventDefault();
                   setIncentiveModalVisible();
                   setModalNumber();
                   modalview();
-                  setRound(2);
+                  setRound(1);
                 }}
                 tokenName={balance.tokenName}
                 isWrongMainnet={isWrongMainnet}
               />
             </div>
+          ) : (
+            <></>
           )}
           <div className="deposit__table__body__loan-list">
             <div>

--- a/src/components/Deposit/TokenTable.tsx
+++ b/src/components/Deposit/TokenTable.tsx
@@ -34,6 +34,7 @@ import { pricesFetcher } from 'src/clients/Coingecko';
 import priceMiddleware from 'src/middleware/priceMiddleware';
 import { IReserveSubgraphData } from 'src/core/types/reserveSubgraph';
 import useReserveData from 'src/hooks/useReserveData';
+import CurrentRewardAmount from 'src/components/Staking/CurrentRewardAmount';
 import TableBodyEventReward from './TableBodyEventReward';
 
 const LazyImage = lazy(() => import('src/utiles/lazyImage'));
@@ -241,6 +242,15 @@ const TokenTable: React.FC<Props> = ({
                 }
                 tokenName={'ELFI'}
                 loading={account ? loading : false}
+                rewardUSDAmount={
+                  <CurrentRewardAmount
+                    tokenUsdPrice={priceData?.elfiPrice || 0}
+                    isLoading={account ? loading : false}
+                    roundData={constants.Zero}
+                    rewardBefore={balance.expectedAdditionalIncentiveBefore}
+                    rewardValue={balance.expectedAdditionalIncentiveAfter}
+                  />
+                }
               />
             </div>
           </div>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -220,7 +220,7 @@
 
       "lp_token_reward_plan": "ELFI, ETH, DAI Reward plan",
 
-      "deposit_add_reward_event": "<strong>New</strong> amount of rewards",
+      "deposit_add_reward_event": "Legacy amount of rewards",
       "claim_before_withraw_guide": "Please claim your rewards first to use your deposit/withdrawal! The reward tokens you will receive are ELFI reward tokens accumulated from <strong>2021.7.15 ~ 2022.1.11 KST!</strong>",
       "claim_question": "Do you want to claim rewards?",
 

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -227,7 +227,7 @@
       "receive_lp_token": "{{token0}}-{{token1}} LP 토큰 받기",
       "lp_token_reward_plan": "ETH, DAI, ELFI 보상 플랜",
 
-      "deposit_add_reward_event": "<strong>New</strong> 보상 수량",
+      "deposit_add_reward_event": "이전 보상 수량",
       "claim_before_withraw_guide": "예치/출금을 이용하기 위해 보상 토큰을 먼저 수령해주세요! 수령할 보상 토큰은 <strong>2021.7.15 ~ 2022.1.11 KST</strong> 에 쌓인 ELFI 보상 토큰입니다.",
       "claim_question": "보상 토큰을 수령하시겠습니까?",
 

--- a/src/stylesheet/public.scss
+++ b/src/stylesheet/public.scss
@@ -1122,6 +1122,9 @@ input[type='number'] {
             }
             > p {
               color: $gray-font-color;
+              > span {
+                color: $gray-font-color;
+              }
             }
           }
 


### PR DESCRIPTION
보상 수량과 이전 보상수량의 위치를 바꾼 뒤, 값이 없으면 이전 보상수량을 가리도록 변경했습니다.

<img width="1037" alt="스크린샷 2022-05-03 오후 4 48 20" src="https://user-images.githubusercontent.com/59865307/166419785-f51ffb06-f340-4256-8666-152d0d1499e2.png">
값이 있을 때,

<img width="1037" alt="스크린샷 2022-05-03 오후 4 48 38" src="https://user-images.githubusercontent.com/59865307/166419815-e4006beb-6c89-4a1f-ae60-f2220202b99a.png">
값이 없을 때,

---

balance.expectedIncentiveBefore.gt(0)를 사용해 이전 스테이킹 값 여부를 확인하며, 신 보상 수량에는 원래 있었던 라운드 타임을 제거한 뒤 해당 자리에 보상 수량의 달러 가치를 추가했습니다. (예치 수량의 경우, 어차피 스테이블 코인이라 작업하지 않았습니다)

해당 브랜치에서는 그 외 다른 기능은 없습니다.
