### PR TITLE
Impl/read only stakingpool

### DIFF
--- a/src/components/Staking/ElfiTitle.tsx
+++ b/src/components/Staking/ElfiTitle.tsx
@@ -57,7 +57,7 @@ const ElfiTitle: React.FC<Props> = ({ headerRef, getMainnetType }) => {
                 ]
             ).map((value, index) => {
               return (
-                <Suspense fallback={null}>
+                <Suspense fallback={null} key={index}>
                   <TitleButton
                     key={`btn_${index}`}
                     buttonName={t(

--- a/src/components/Staking/hooks/useReadOnlyStakingPool.ts
+++ b/src/components/Staking/hooks/useReadOnlyStakingPool.ts
@@ -1,0 +1,36 @@
+import { StakingPoolV2, StakingPoolV2factory } from '@elysia-dev/elyfi-v1-sdk';
+import { providers } from 'ethers';
+import { useContext, useMemo } from 'react';
+import envs from 'src/core/envs';
+import Token from 'src/enums/Token';
+import MainnetContext from 'src/contexts/MainnetContext';
+import MainnetType from 'src/enums/MainnetType';
+
+const useReadOnlyStakingPool = (
+  stakedToken: Token,
+): StakingPoolV2 => {
+  const { type: mainnet } = useContext(MainnetContext);
+
+  const stakingPool = useMemo(() => {
+    return StakingPoolV2factory.connect(
+      stakedToken === Token.ELFI
+        ? mainnet === MainnetType.BSC
+          ? envs.stakingV2MoneyPool.elfiBscStaking
+          : envs.stakingV2MoneyPool.elfiStaking
+        : stakedToken === Token.ELFI_ETH_LP
+        ? envs.stakingV2MoneyPool.elfiEthLp
+        : stakedToken === Token.ELFI_DAI_LP
+        ? envs.stakingV2MoneyPool.elfiDaiLp
+        : envs.stakingV2MoneyPool.elfiStaking,
+      new providers.JsonRpcProvider(
+        mainnet === MainnetType.BSC
+          ? envs.jsonRpcUrl.bsc
+          : process.env.REACT_APP_JSON_RPC,
+      ) as any,
+    );
+  }, [stakedToken, mainnet]);
+
+  return stakingPool
+};
+
+export default useReadOnlyStakingPool;

--- a/src/components/Staking/hooks/useStakingFetchRoundDataV2.ts
+++ b/src/components/Staking/hooks/useStakingFetchRoundDataV2.ts
@@ -14,7 +14,7 @@ import RoundData from 'src/core/types/RoundData';
 import calcAPR from 'src/core/utils/calcAPR';
 import Token from 'src/enums/Token';
 import priceMiddleware from 'src/middleware/priceMiddleware';
-import useStakingPoolV2 from './useStakingPoolV2';
+import useReadOnlyStakingPool from './useReadOnlyStakingPool';
 
 const useStakingFetchRoundDataV2 = (
   stakedToken: Token,
@@ -28,8 +28,7 @@ const useStakingFetchRoundDataV2 = (
 } => {
   const { type: getMainnetType } = useContext(MainnetContext);
   const { account } = useWeb3React();
-  const { contract: stakingPool } = useStakingPoolV2(stakedToken);
-
+  const stakingPool = useReadOnlyStakingPool(stakedToken)
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const [roundData, setroundData] = useState<RoundData[]>([]);

--- a/src/components/Staking/hooks/useStakingRoundDataV2.ts
+++ b/src/components/Staking/hooks/useStakingRoundDataV2.ts
@@ -1,6 +1,5 @@
-import { StakingPoolV2, StakingPoolV2factory } from '@elysia-dev/elyfi-v1-sdk';
-import { BigNumber, constants, providers } from 'ethers';
-import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { BigNumber, constants } from 'ethers';
+import { useCallback, useContext, useEffect, useState } from 'react';
 import useSWR from 'swr';
 
 import envs from 'src/core/envs';
@@ -17,6 +16,7 @@ import { pricesFetcher } from 'src/clients/Coingecko';
 import priceMiddleware from 'src/middleware/priceMiddleware';
 import calcLpAPR from 'src/core/utils/calcLpAPR';
 import { parseEther } from 'ethers/lib/utils';
+import useReadOnlyStakingPool from './useReadOnlyStakingPool';
 
 const useStakingRoundDataV2 = (
   stakedToken: Token,
@@ -27,25 +27,7 @@ const useStakingRoundDataV2 = (
   loading: boolean;
 } => {
   const { type: mainnet } = useContext(MainnetContext);
-
-  const stakingPool = useMemo(() => {
-    return StakingPoolV2factory.connect(
-      stakedToken === Token.ELFI
-        ? mainnet === MainnetType.BSC
-          ? envs.stakingV2MoneyPool.elfiBscStaking
-          : envs.stakingV2MoneyPool.elfiStaking
-        : stakedToken === Token.ELFI_ETH_LP
-        ? envs.stakingV2MoneyPool.elfiEthLp
-        : stakedToken === Token.ELFI_DAI_LP
-        ? envs.stakingV2MoneyPool.elfiDaiLp
-        : envs.stakingV2MoneyPool.elfiStaking,
-      new providers.JsonRpcProvider(
-        mainnet === MainnetType.BSC
-          ? envs.jsonRpcUrl.bsc
-          : process.env.REACT_APP_JSON_RPC,
-      ) as any,
-    );
-  }, [stakedToken, mainnet]);
+  const stakingPool = useReadOnlyStakingPool(stakedToken);
 
   const { data: priceData } = useSWR(
     envs.externalApiEndpoint.coingackoURL,


### PR DESCRIPTION
## 문제점
몇몇 유저의 경우 stakingpool data를 받을 수 없는 버그가 있었습니다. 추측하기로는 BSC json rpc endpoint가 metamask에 의존하고 있는 경우에 문제가 조금 있는것 같습니다. BSC는 [endpoint](https://docs.binance.org/smart-chain/developer/rpc.html)를 여러개 제공하고 있는데, metamask가 제공하는 endpoint는 유저가 수정이 가능하고, 또한 유저가 지정한 endpoint에서 Read 할때 문제가 발생할 수 있었던 것 같습니다. 따라서 모두가 겪지는 않지만, 몇몇은 겪는 문제가 발생했던 것 같아요.

## 작업 내용
* 데이터를 불러올때 사용하는 BSC endpoint 고정 : Staking 정보를 불러오는 컨트랙트를 ReadOnlyStakingPool로 정의하고, 해당 컨트랙트의 Provider는 메타마스크가 아니라 우리가 지정한 RPC Endpoint를 가르키도록 했습니다. 물론 이 경우도 문제를 해결하지는 못할 수도 있는데, 지켜봐야할 것 같습니다. 제 메타마스크의 경우 종종 bsc에서 스로틀 문제가 있었습니다.
* Add key : Staking 페이지에서 발생하던 사소한 key문제도 같이 해결했습니다.