### PR TITLE
change get html links

### DIFF
--- a/src/components/Governance/OffchainContainer.tsx
+++ b/src/components/Governance/OffchainContainer.tsx
@@ -27,7 +27,7 @@ const OffChainContainer: React.FC<Props> = ({ data }) => {
       <Suspense fallback={<FallbackSkeleton width={'100%'} height={300} />}>
         <div>
           <img
-            src={`https://${data.images}`}
+            src={data.images}
             alt="vote image"
             onError={(e: any) => {
               e.target.src = UnKnownImage;

--- a/src/middleware/offChainMiddleware.tsx
+++ b/src/middleware/offChainMiddleware.tsx
@@ -11,6 +11,7 @@ export const offChainGovernanceMiddleware: Middleware =
   (useSWRNext: SWRHook) => (key, fetcher, config) => {
     const swr = useSWRNext(key, fetcher, config);
     const dataRef = useRef<any>(null);
+    const htmlParser = new DOMParser();
     const [offChainLoading, setOffChainLoading] = useState(true);
     const [offChainNapData, setOffChainNapData] = useState<
       {
@@ -37,7 +38,6 @@ export const offChainGovernanceMiddleware: Middleware =
               const getNATData = await OffChainTopic.getTopicResult(_res);
               const getHTMLStringData: string =
                 getNATData.data.post_stream.posts[0].cooked.toString();
-              const htmlParser = new DOMParser();
               const parsedHTMLData = htmlParser.parseFromString(
                 getHTMLStringData,
                 'text/html',

--- a/src/middleware/offChainMiddleware.tsx
+++ b/src/middleware/offChainMiddleware.tsx
@@ -37,6 +37,15 @@ export const offChainGovernanceMiddleware: Middleware =
               const getNATData = await OffChainTopic.getTopicResult(_res);
               const getHTMLStringData: string =
                 getNATData.data.post_stream.posts[0].cooked.toString();
+              const htmlParser = new DOMParser();
+              const parsedHTMLData = htmlParser.parseFromString(
+                getHTMLStringData,
+                'text/html',
+              );
+              const getAllAnchorTag = parsedHTMLData.body.querySelectorAll('a');
+              const result = Array.from(getAllAnchorTag).find((arrayData) => {
+                return arrayData.innerHTML === 'Collateral Image';
+              });
               const regexNap = /NAP#: .*(?=<)/;
               const regexNetwork = /Network: BSC.*(?=<)/;
               setOffChainNapData((napData: any) => [
@@ -53,12 +62,7 @@ export const offChainGovernanceMiddleware: Middleware =
                       .match(/Status: .*(?=<)/)
                       ?.toString()
                       .split('Status: ') || '',
-                  images:
-                    getHTMLStringData
-                      .match(
-                        /slate.textile.io.*(?=" rel="noopener nofollow ugc">Collateral Image)/,
-                      )
-                      ?.toString() || '',
+                  images: result?.href || '',
                   votes: getNATData.data.post_stream.posts[0].polls
                     ? getNATData.data.post_stream.posts[0].polls[0].options
                     : ([

--- a/src/middleware/offChainMiddleware.tsx
+++ b/src/middleware/offChainMiddleware.tsx
@@ -44,7 +44,9 @@ export const offChainGovernanceMiddleware: Middleware =
               );
               const getAllAnchorTag = parsedHTMLData.body.querySelectorAll('a');
               const result = Array.from(getAllAnchorTag).find((arrayData) => {
-                return arrayData.innerHTML === 'Collateral Image';
+                return (
+                  arrayData.innerHTML.toLocaleLowerCase() === 'collateral image'
+                );
               });
               const regexNap = /NAP#: .*(?=<)/;
               const regexNetwork = /Network: BSC.*(?=<)/;


### PR DESCRIPTION
거버넌스 이미지 파일을 불러오는 방식을 변경했습니다.
기존 정규표현식을 사용하던 방법에서 HTMLparser를 사용해 Collateral Image 라는 텍스트를 가진 anchor 태그의 href를 불러오도록 설정했습니다.

해당 브랜치에서는 그 외 다른 기능은 없습니다.