### PR TITLE
fix hover action

### DIFF
--- a/src/stylesheet/public.scss
+++ b/src/stylesheet/public.scss
@@ -96,7 +96,11 @@ $bold: 'Inter-Bold', 'SpoqaHanSansNeo-Bold', 'Montserrat-bold', 'Inter-Bold';
   }
   &:hover {
     box-shadow: 0px 0px 15px #00a7ff66;
-    transform: translateY(-5px);
+    transform: translateY(-3px);
+    &::after {
+      position: absolute;
+      transform: translateY(6px);
+    }
   }
   &:active {
     transform: translateY(-1px);
@@ -126,7 +130,11 @@ $bold: 'Inter-Bold', 'SpoqaHanSansNeo-Bold', 'Montserrat-bold', 'Inter-Bold';
   }
   &:hover {
     box-shadow: 0px 0px 15px #00a7ff66;
-    transform: translateY(-5px);
+    transform: translateY(-3px);
+    &::after {
+      position: absolute;
+      transform: translateY(6px);
+    }
   }
   &:active {
     transform: translateY(-1px);


### PR DESCRIPTION
버튼 호버가 너무 높이 올라가서 클릭에 문제가 있던 이슈를 수정했습니다.
올라가는 범위를 줄였고, 하단에 ::after를 사용해서 버튼이 위로 올라갔을 때 호버영역이 풀리지 않도록 조치했습니다.

해당 브랜치에서는 그 외 다른 기능은 없습니다