### PR TITLE
baseUrl temporarily changed

### DIFF
--- a/src/clients/Slate.ts
+++ b/src/clients/Slate.ts
@@ -18,7 +18,7 @@ export interface ISlateResponse {
   }[];
 }
 
-export const baseUrl = 'https://ipfs.io/ipfs/';
+export const baseUrl = 'https://ipfs.io/ipfs';
 
 export class Slate {
   static fetctABTokenIpfs = async (

--- a/src/clients/Slate.ts
+++ b/src/clients/Slate.ts
@@ -18,7 +18,7 @@ export interface ISlateResponse {
   }[];
 }
 
-export const baseUrl = 'https://elysia-public.s3.ap-northeast-2.amazonaws.com/ipfs';
+export const baseUrl = 'https://ipfs.io/ipfs/';
 
 export class Slate {
   static fetctABTokenIpfs = async (


### PR DESCRIPTION
기존 url에서 403 에러가 출력되서 페이지가 정상적으로 나오지 않는 이슈가 발생해 https://ipfs.io/ipfs 로 baseUrl을 수정했습니다.
우선 임시적으로 링크를 변경했으며 추후 다시 확인해야 합니다.

해당 브랜치에서는 그 외 다른 기능은 없습니다.