### PR TITLE
Update baseurl

### DIFF
--- a/src/clients/Slate.ts
+++ b/src/clients/Slate.ts
@@ -18,7 +18,8 @@ export interface ISlateResponse {
   }[];
 }
 
-export const baseUrl = 'https://ipfs.io/ipfs';
+// Cached url
+export const baseUrl = 'https://elysia-public.s3.ap-northeast-2.amazonaws.com/ipfs';
 
 export class Slate {
   static fetctABTokenIpfs = async (

--- a/src/components/Portfolio/index.tsx
+++ b/src/components/Portfolio/index.tsx
@@ -96,32 +96,23 @@ const PortfolioDetail: FunctionComponent = () => {
         setContractImage([
           {
             hash: contractDoc.documents[0].hash,
-            link: contractDoc.documents[0].link.replace(
-              'https://slate.textile.io',
-              'https://ipfs.io',
-            ),
+            link: contractDoc.documents[0].link
           },
           {
             hash:
               contractDoc.documents[1].hash ===
-              'bafybafybeib7azwyp4abkaoh3zpwygjhqkluborvt2cy255fvnq4a6o6qkkxla'
+                'bafybafybeib7azwyp4abkaoh3zpwygjhqkluborvt2cy255fvnq4a6o6qkkxla'
                 ? 'bafybeib7azwyp4abkaoh3zpwygjhqkluborvt2cy255fvnq4a6o6qkkxla'
                 : contractDoc.documents[1].hash,
             link:
               contractDoc.documents[1].hash ===
-              'bafybafybeib7azwyp4abkaoh3zpwygjhqkluborvt2cy255fvnq4a6o6qkkxla'
-                ? 'https://ipfs.io/ipfs/bafybeib7azwyp4abkaoh3zpwygjhqkluborvt2cy255fvnq4a6o6qkkxla'
-                : contractDoc.documents[1].link.replace(
-                    'https://slate.textile.io',
-                    'https://ipfs.io',
-                  ),
+                'bafybafybeib7azwyp4abkaoh3zpwygjhqkluborvt2cy255fvnq4a6o6qkkxla'
+                ? 'https://slate.textile.io/ipfs/bafybeib7azwyp4abkaoh3zpwygjhqkluborvt2cy255fvnq4a6o6qkkxla'
+                : contractDoc.documents[1].link
           },
           {
             hash: contractDoc.documents[2].hash,
-            link: contractDoc.documents[2].link.replace(
-              'https://slate.textile.io',
-              'https://ipfs.io',
-            ),
+            link: contractDoc.documents[2].link
           },
           {
             hash: contractDoc.images[0]?.hash,


### PR DESCRIPTION
이제 json파일과 이미지 파일은 s3에 캐싱하도록 변경했습니다. 다만 계약서 파일들은 아직 s3에 업로드하지못하여, 계약서 파일들은 링크를 통해 접근할 수 있도록 코드를 수정했습니다.