### PR TITLE
Feat/withdraw nfts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "start": "REACT_APP_TEST_MODE=y react-scripts start",
+    "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "e2etest": "cypress open",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "start": "react-scripts start",
+    "start": "REACT_APP_TEST_MODE=y react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "e2etest": "cypress open",

--- a/src/assets/images/market/new_tab--button.svg
+++ b/src/assets/images/market/new_tab--button.svg
@@ -1,0 +1,6 @@
+<svg id="그룹_7041" data-name="그룹 7041" xmlns="http://www.w3.org/2000/svg" width="17.999" height="17.999" viewBox="0 0 17.999 17.999">
+  <path id="패스_10301" data-name="패스 10301" d="M0,0H18V18H0Z" fill="none"/>
+  <path id="패스_10302" data-name="패스 10302" d="M9.25,7H5.5A1.5,1.5,0,0,0,4,8.5v6.75a1.5,1.5,0,0,0,1.5,1.5h6.75a1.5,1.5,0,0,0,1.5-1.5V11.5" transform="translate(-1 -1.75)" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+  <line id="선_10023" data-name="선 10023" y1="8" x2="8" transform="translate(7 2.999)" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+  <path id="패스_10303" data-name="패스 10303" d="M15,4h3.75V7.75" transform="translate(-3.75 -1)" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="1"/>
+</svg>

--- a/src/components/Market/Modals/InvestmentRewardModal.tsx
+++ b/src/components/Market/Modals/InvestmentRewardModal.tsx
@@ -1,8 +1,5 @@
 import { Trans, useTranslation } from 'react-i18next';
-import {
-  formatCommaSmallTwoDisits,
-  formatCommaSmallZeroDisits,
-} from 'src/utiles/formatters';
+import { formatCommaSmallTwoDisits } from 'src/utiles/formatters';
 
 interface Props {
   onClose: () => void;
@@ -10,6 +7,7 @@ interface Props {
   usdcPerNft: number;
   eventReward: number;
   nftInterest: number;
+  onSubmit: () => void;
 }
 
 const InvestRewardModal: React.FC<Props> = ({
@@ -18,6 +16,7 @@ const InvestRewardModal: React.FC<Props> = ({
   usdcPerNft,
   eventReward,
   nftInterest,
+  onSubmit,
 }) => {
   const { t, i18n } = useTranslation();
 
@@ -26,7 +25,7 @@ const InvestRewardModal: React.FC<Props> = ({
       <div className="market_modal" style={{ display: 'block' }}>
         <div className="market_modal__wrapper">
           <header className={`market_modal__header `}>
-            <h3>수익금 수령하기</h3>
+            <h3>{t('nftModal.reward.title')}</h3>
             <div onClick={onClose}>
               <div></div>
               <div></div>
@@ -34,18 +33,18 @@ const InvestRewardModal: React.FC<Props> = ({
           </header>
           <div className="market_modal__investment-reward">
             <section className="market_modal__investment-reward__burn">
-              <b>나의 보유수량</b>
+              <b>{t('nftModal.reward.currentHolding')}</b>
               <div>
                 <b>
                   {formatCommaSmallTwoDisits(holdingNft)}
                   <span>NFT(S)</span>
                 </b>
               </div>
-              <p>* 수익금 수령 시, 해당 NFT 전부 소각됩니다.</p>
+              <p>{t('nftModal.reward.content')}</p>
             </section>
             <section className="market_modal__investment-reward__current">
               <div>
-                <b>나의 수익금</b>
+                <b>{t('nftModal.reward.currentReward')}</b>
                 <b>
                   {formatCommaSmallTwoDisits(
                     holdingNft * (usdcPerNft + nftInterest) + eventReward,
@@ -55,7 +54,7 @@ const InvestRewardModal: React.FC<Props> = ({
               </div>
               <section>
                 <div>
-                  <p>상환금</p>
+                  <p>{t('nftModal.reward.repayment')}</p>
                   <p>
                     {formatCommaSmallTwoDisits(
                       holdingNft * (usdcPerNft + nftInterest),
@@ -64,7 +63,7 @@ const InvestRewardModal: React.FC<Props> = ({
                   </p>
                 </div>
                 <div>
-                  <p>이벤트 보상</p>
+                  <p>{t('nftModal.reward.eventReward')}</p>
                   <p>
                     {formatCommaSmallTwoDisits(eventReward)}
                     <span>USDC</span>
@@ -74,7 +73,7 @@ const InvestRewardModal: React.FC<Props> = ({
             </section>
           </div>
           <div className={`market_modal__investment-reward__button `}>
-            <button>승인하기</button>
+            <button onClick={onSubmit}>{t('nftModal.reward.claim')}</button>
           </div>
         </div>
       </div>

--- a/src/components/Market/Modals/InvestmentRewardModal.tsx
+++ b/src/components/Market/Modals/InvestmentRewardModal.tsx
@@ -2,6 +2,8 @@ import { Trans, useTranslation } from 'react-i18next';
 
 interface Props {
   onClose: () => void;
+  holdingNft: number;
+  nftPerUsdc: number;
 }
 
 const InvestRewardModal: React.FC<Props> = ({ onClose }) => {
@@ -26,7 +28,6 @@ const InvestRewardModal: React.FC<Props> = ({ onClose }) => {
                   123,456<span>NFT(S)</span>
                 </b>
               </div>
-
               <p>* 수익금 수령 시, 해당 NFT 전부 소각됩니다.</p>
             </section>
             <section className="market_modal__investment-reward__current">
@@ -52,7 +53,7 @@ const InvestRewardModal: React.FC<Props> = ({ onClose }) => {
               </section>
             </section>
           </div>
-          <div className="market_modal__investment-reward__button">
+          <div className={`market_modal__investment-reward__button `}>
             <button>승인하기</button>
           </div>
         </div>

--- a/src/components/Market/Modals/InvestmentRewardModal.tsx
+++ b/src/components/Market/Modals/InvestmentRewardModal.tsx
@@ -1,12 +1,24 @@
 import { Trans, useTranslation } from 'react-i18next';
+import {
+  formatCommaSmallTwoDisits,
+  formatCommaSmallZeroDisits,
+} from 'src/utiles/formatters';
 
 interface Props {
   onClose: () => void;
   holdingNft: number;
   usdcPerNft: number;
+  eventReward: number;
+  nftInterest: number;
 }
 
-const InvestRewardModal: React.FC<Props> = ({ onClose }) => {
+const InvestRewardModal: React.FC<Props> = ({
+  onClose,
+  holdingNft,
+  usdcPerNft,
+  eventReward,
+  nftInterest,
+}) => {
   const { t, i18n } = useTranslation();
 
   return (
@@ -25,7 +37,8 @@ const InvestRewardModal: React.FC<Props> = ({ onClose }) => {
               <b>나의 보유수량</b>
               <div>
                 <b>
-                  123,456<span>NFT(S)</span>
+                  {formatCommaSmallTwoDisits(holdingNft)}
+                  <span>NFT(S)</span>
                 </b>
               </div>
               <p>* 수익금 수령 시, 해당 NFT 전부 소각됩니다.</p>
@@ -34,20 +47,27 @@ const InvestRewardModal: React.FC<Props> = ({ onClose }) => {
               <div>
                 <b>나의 수익금</b>
                 <b>
-                  123.34<span>USDC</span>
+                  {formatCommaSmallTwoDisits(
+                    holdingNft * (usdcPerNft + nftInterest) + eventReward,
+                  )}
+                  <span>USDC</span>
                 </b>
               </div>
               <section>
                 <div>
                   <p>상환금</p>
                   <p>
-                    100<span>USDC</span>
+                    {formatCommaSmallTwoDisits(
+                      holdingNft * (usdcPerNft + nftInterest),
+                    )}
+                    <span>USDC</span>
                   </p>
                 </div>
                 <div>
                   <p>이벤트 보상</p>
                   <p>
-                    100<span>USDC</span>
+                    {formatCommaSmallTwoDisits(eventReward)}
+                    <span>USDC</span>
                   </p>
                 </div>
               </section>

--- a/src/components/Market/Modals/InvestmentRewardModal.tsx
+++ b/src/components/Market/Modals/InvestmentRewardModal.tsx
@@ -3,7 +3,7 @@ import { Trans, useTranslation } from 'react-i18next';
 interface Props {
   onClose: () => void;
   holdingNft: number;
-  nftPerUsdc: number;
+  usdcPerNft: number;
 }
 
 const InvestRewardModal: React.FC<Props> = ({ onClose }) => {

--- a/src/components/Market/Modals/InvestmentRewardModal.tsx
+++ b/src/components/Market/Modals/InvestmentRewardModal.tsx
@@ -1,0 +1,64 @@
+import { Trans, useTranslation } from 'react-i18next';
+
+interface Props {
+  onClose: () => void;
+}
+
+const InvestRewardModal: React.FC<Props> = ({ onClose }) => {
+  const { t, i18n } = useTranslation();
+
+  return (
+    <>
+      <div className="market_modal" style={{ display: 'block' }}>
+        <div className="market_modal__wrapper">
+          <header className={`market_modal__header `}>
+            <h3>수익금 수령하기</h3>
+            <div onClick={onClose}>
+              <div></div>
+              <div></div>
+            </div>
+          </header>
+          <div className="market_modal__investment-reward">
+            <section className="market_modal__investment-reward__burn">
+              <b>나의 보유수량</b>
+              <div>
+                <b>
+                  123,456<span>NFT(S)</span>
+                </b>
+              </div>
+
+              <p>* 수익금 수령 시, 해당 NFT 전부 소각됩니다.</p>
+            </section>
+            <section className="market_modal__investment-reward__current">
+              <div>
+                <b>나의 수익금</b>
+                <b>
+                  123.34<span>USDC</span>
+                </b>
+              </div>
+              <section>
+                <div>
+                  <p>상환금</p>
+                  <p>
+                    100<span>USDC</span>
+                  </p>
+                </div>
+                <div>
+                  <p>이벤트 보상</p>
+                  <p>
+                    100<span>USDC</span>
+                  </p>
+                </div>
+              </section>
+            </section>
+          </div>
+          <div className="market_modal__investment-reward__button">
+            <button>승인하기</button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default InvestRewardModal;

--- a/src/components/Market/NFTCard.tsx
+++ b/src/components/Market/NFTCard.tsx
@@ -19,7 +19,6 @@ const NFTCard: React.FC<{ data: ICardType }> = ({ data }) => {
             src={data.cardImage === undefined ? TempAsset : data.cardImage}
             alt="NFT Images"
             onError={(e: any) => {
-              console.log('123');
               e.target.src = TempAsset;
             }}
           />

--- a/src/components/Market/index.tsx
+++ b/src/components/Market/index.tsx
@@ -28,15 +28,6 @@ export interface ICardType {
 }
 
 const tempCardArray: ICardType[] = [
-  // {
-  //   PFType: PFType.BOND,
-  //   Location: '2046 Norwalk Ave, LA, CA 90041',
-  //   APY: 12,
-  //   currentSoldNFTs: 0,
-  //   totalNFTs: 54000,
-  //   cardImage: BondAsset,
-  //   onClickLink: 'a1',
-  // },
   {
     PFType: PFType.SHARE,
     Location: '',
@@ -68,14 +59,18 @@ const Market = (): JSX.Element => {
     fetcher: nftTotalSupplyFetcher(),
   });
 
+  const OFF_CHAIN_SELLING_AMOUNT = 560000;
+  const USDC_PER_NFT = 10;
+  const TOTAL_AMOUNT = 1100000;
+
   useEffect(() => {
     if (nftTotalSupply === undefined) return;
     const nft = {
       PFType: PFType.BOND,
       Location: '2046 Norwalk Ave, LA, CA 90041',
       APY: 12,
-      currentSoldNFTs: nftTotalSupply,
-      totalNFTs: 54000,
+      currentSoldNFTs: OFF_CHAIN_SELLING_AMOUNT + nftTotalSupply * USDC_PER_NFT,
+      totalNFTs: TOTAL_AMOUNT,
       cardImage: BondAsset,
       onClickLink: 'bondnft/0',
     };

--- a/src/components/Market/index.tsx
+++ b/src/components/Market/index.tsx
@@ -129,9 +129,6 @@ const Market = (): JSX.Element => {
         <article className="market__content">
           <h2>{t('market.useRealEstateInfo')}</h2>
           <article className="market__nft-container">
-            {/* {tempCardArray.map((data, index) => {
-              return <NFTCard data={data} key={index} />;
-            })} */}
             {tempCards
               ? tempCards.map((data, index) => {
                   return <NFTCard data={data} key={index} />;

--- a/src/components/NFTDetails/Header.tsx
+++ b/src/components/NFTDetails/Header.tsx
@@ -103,7 +103,7 @@ const Header: React.FC<Props> = ({
       <button
         onClick={onRewardButtonClick}
         className={isMoneypoolCharged ? '' : 'disabled'}>
-        수령하기
+        {t('nftMarket.claim')}
       </button>
     );
   };
@@ -125,7 +125,9 @@ const Header: React.FC<Props> = ({
               <span>
                 <Questionmark
                   content={
-                    '나의 예상 수익금은 보유한 채권 NFT로 수령할 수 있는 수익금을 나타냅니다. 상환일에 따라 이자가 변경되기 때문에 실제 수익금이 예상 수익금과 달라질 수 있습니다.'
+                    inviteFriendReward > 0
+                      ? t('nftMarket.contentAfterEvent')
+                      : t('nftMarket.expectedContent')
                   }
                 />
               </span>

--- a/src/components/NFTDetails/Header.tsx
+++ b/src/components/NFTDetails/Header.tsx
@@ -5,7 +5,7 @@ import { Link, useParams } from 'react-router-dom';
 import Questionmark from 'src/components/Questionmark';
 import MainnetType from 'src/enums/MainnetType';
 import NewTab from 'src/assets/images/market/new_tab--button.svg';
-import { formatCommaSmallZeroDisits } from 'src/utiles/formatters';
+import { formatCommaSmallTwoDisits } from 'src/utiles/formatters';
 
 interface Props {
   onButtonClick: () => void;
@@ -47,7 +47,7 @@ const Header: React.FC<Props> = ({
           t('nftMarket.purchaseStatus.nullPurchase')
         ) : (
           <>
-            {formatCommaSmallZeroDisits(purchasedNFT)}
+            {formatCommaSmallTwoDisits(purchasedNFT)}
             <span> NFT(s)</span>
           </>
         )
@@ -68,7 +68,7 @@ const Header: React.FC<Props> = ({
           t('nftMarket.purchaseStatus.nullPurchase')
         ) : (
           <>
-            {formatCommaSmallZeroDisits(
+            {formatCommaSmallTwoDisits(
               purchasedNFT * (usdcPerNft + nftInterest) + inviteFriendReward,
             )}
             <span> USDC</span>

--- a/src/components/NFTDetails/Header.tsx
+++ b/src/components/NFTDetails/Header.tsx
@@ -4,9 +4,11 @@ import Skeleton from 'react-loading-skeleton';
 import { Link, useParams } from 'react-router-dom';
 import Questionmark from 'src/components/Questionmark';
 import MainnetType from 'src/enums/MainnetType';
+import NewTab from 'src/assets/images/market/new_tab--button.svg';
 
 interface Props {
   onButtonClick: () => void;
+  onRewardButtonClick: () => void;
   purchasedNFT?: number;
   isDisabled: boolean;
   mainnetType: MainnetType;
@@ -19,6 +21,7 @@ const Header: React.FC<Props> = ({
   isDisabled,
   mainnetType,
   openseaLink,
+  onRewardButtonClick,
 }) => {
   const { t } = useTranslation();
   const { account } = useWeb3React();
@@ -45,7 +48,8 @@ const Header: React.FC<Props> = ({
   const AnchorLinkComponent = (): JSX.Element => {
     return (
       <a href={openseaLink} target="_blank">
-        {t('nftMarket.tradeOnOpensea')}
+        {t('nftMarket.tradeOnOpensea')}{' '}
+        <img src={NewTab} alt="New tab link icon" />
       </a>
     );
   };
@@ -57,13 +61,18 @@ const Header: React.FC<Props> = ({
       </button>
     );
   };
+  const RewardComponent = (): JSX.Element => {
+    return (
+      <button
+        onClick={onRewardButtonClick}
+        className={isDisabled ? '' : 'disabled'}>
+        수령하기
+      </button>
+    );
+  };
 
   return (
     <>
-      <div>
-        <h1>{t('nftMarket.title')}</h1>
-        <p>{t('nftMarket.subTitle')}</p>
-      </div>
       <Link
         className="nft-details__guide mobile-only"
         to={{
@@ -71,35 +80,69 @@ const Header: React.FC<Props> = ({
         }}>
         {t('nftMarket.guide')}
       </Link>
-      <section>
-        <div>
-          <b>
-            {t('nftMarket.myPurchase')}
-            <span>
-              <Questionmark
-                content={
-                  <Trans i18nKey={'nftMarket.myPurchaseInfo'}>
-                    text
-                    <u>
-                      <a
-                        target="_blank"
-                        href="https://etherscan.io/"
-                        style={{ color: '#00bfff' }}>
-                        link
-                      </a>
-                    </u>
-                  </Trans>
-                }
-              />
-            </span>
-          </b>
-          <span>{currentPurchaseAmount()}</span>
-        </div>
-        <section>
-          <AnchorLinkComponent />
-          <ButtonComponent />
+      <article>
+        <section className="nft-details__current-nfts__expected-reward">
+          <div>
+            <b>
+              나의 예상수익금
+              <span>
+                <Questionmark
+                  content={
+                    <Trans i18nKey={'nftMarket.myPurchaseInfo'}>
+                      text
+                      <u>
+                        <a
+                          target="_blank"
+                          href="https://etherscan.io/"
+                          style={{ color: '#00bfff' }}>
+                          link
+                        </a>
+                      </u>
+                    </Trans>
+                  }
+                />
+              </span>
+            </b>
+          </div>
+          <section>
+            <b>{currentPurchaseAmount()}</b>
+            <section>
+              <RewardComponent />
+            </section>
+          </section>
         </section>
-      </section>
+        <section className="nft-details__current-nfts__holds">
+          <div>
+            <b>
+              {t('nftMarket.myPurchase')}
+              <span>
+                <Questionmark
+                  content={
+                    <Trans i18nKey={'nftMarket.myPurchaseInfo'}>
+                      text
+                      <u>
+                        <a
+                          target="_blank"
+                          href="https://etherscan.io/"
+                          style={{ color: '#00bfff' }}>
+                          link
+                        </a>
+                      </u>
+                    </Trans>
+                  }
+                />
+              </span>
+            </b>
+          </div>
+          <section>
+            <b>{currentPurchaseAmount()}</b>
+            <section>
+              <AnchorLinkComponent />
+              <ButtonComponent />
+            </section>
+          </section>
+        </section>
+      </article>
     </>
   );
 };

--- a/src/components/NFTDetails/Header.tsx
+++ b/src/components/NFTDetails/Header.tsx
@@ -5,14 +5,20 @@ import { Link, useParams } from 'react-router-dom';
 import Questionmark from 'src/components/Questionmark';
 import MainnetType from 'src/enums/MainnetType';
 import NewTab from 'src/assets/images/market/new_tab--button.svg';
+import { formatCommaSmallZeroDisits } from 'src/utiles/formatters';
 
 interface Props {
   onButtonClick: () => void;
   onRewardButtonClick: () => void;
+  rewardTitle: string;
   purchasedNFT?: number;
   isDisabled: boolean;
   mainnetType: MainnetType;
   openseaLink: string;
+  isMoneypoolCharged: boolean;
+  nftPerUsdc: number;
+  nftInterest: number;
+  inviteFriendReward: number;
 }
 
 const Header: React.FC<Props> = ({
@@ -22,6 +28,11 @@ const Header: React.FC<Props> = ({
   mainnetType,
   openseaLink,
   onRewardButtonClick,
+  inviteFriendReward,
+  rewardTitle,
+  isMoneypoolCharged,
+  nftPerUsdc,
+  nftInterest,
 }) => {
   const { t } = useTranslation();
   const { account } = useWeb3React();
@@ -35,7 +46,33 @@ const Header: React.FC<Props> = ({
         purchasedNFT === 0 ? (
           t('nftMarket.purchaseStatus.nullPurchase')
         ) : (
-          `${purchasedNFT} NFT(s)`
+          <>
+            {formatCommaSmallZeroDisits(purchasedNFT)}
+            <span> NFT(s)</span>
+          </>
+        )
+      ) : (
+        <Skeleton width={100} height={24} />
+      )
+    ) : (
+      t('nftMarket.purchaseStatus.invalidNetwork')
+    );
+  };
+
+  const currentRewardAmount = () => {
+    return account === undefined ? (
+      t('nftMarket.purchaseStatus.walletConnect')
+    ) : mainnetType === MainnetType.Ethereum ? (
+      purchasedNFT !== undefined ? (
+        purchasedNFT === 0 ? (
+          t('nftMarket.purchaseStatus.nullPurchase')
+        ) : (
+          <>
+            {formatCommaSmallZeroDisits(
+              purchasedNFT * (nftPerUsdc + nftInterest) + inviteFriendReward,
+            )}
+            <span> USDC</span>
+          </>
         )
       ) : (
         <Skeleton width={100} height={24} />
@@ -65,7 +102,7 @@ const Header: React.FC<Props> = ({
     return (
       <button
         onClick={onRewardButtonClick}
-        className={isDisabled ? '' : 'disabled'}>
+        className={isMoneypoolCharged ? '' : 'disabled'}>
         수령하기
       </button>
     );
@@ -84,28 +121,18 @@ const Header: React.FC<Props> = ({
         <section className="nft-details__current-nfts__expected-reward">
           <div>
             <b>
-              나의 예상수익금
+              {rewardTitle}
               <span>
                 <Questionmark
                   content={
-                    <Trans i18nKey={'nftMarket.myPurchaseInfo'}>
-                      text
-                      <u>
-                        <a
-                          target="_blank"
-                          href="https://etherscan.io/"
-                          style={{ color: '#00bfff' }}>
-                          link
-                        </a>
-                      </u>
-                    </Trans>
+                    '나의 예상 수익금은 보유한 채권 NFT로 수령할 수 있는 수익금을 나타냅니다. 상환일에 따라 이자가 변경되기 때문에 실제 수익금이 예상 수익금과 달라질 수 있습니다.'
                   }
                 />
               </span>
             </b>
           </div>
           <section>
-            <b>{currentPurchaseAmount()}</b>
+            <b>{currentRewardAmount()}</b>
             <section>
               <RewardComponent />
             </section>

--- a/src/components/NFTDetails/Header.tsx
+++ b/src/components/NFTDetails/Header.tsx
@@ -16,7 +16,7 @@ interface Props {
   mainnetType: MainnetType;
   openseaLink: string;
   isMoneypoolCharged: boolean;
-  nftPerUsdc: number;
+  usdcPerNft: number;
   nftInterest: number;
   inviteFriendReward: number;
 }
@@ -31,7 +31,7 @@ const Header: React.FC<Props> = ({
   inviteFriendReward,
   rewardTitle,
   isMoneypoolCharged,
-  nftPerUsdc,
+  usdcPerNft,
   nftInterest,
 }) => {
   const { t } = useTranslation();
@@ -69,7 +69,7 @@ const Header: React.FC<Props> = ({
         ) : (
           <>
             {formatCommaSmallZeroDisits(
-              purchasedNFT * (nftPerUsdc + nftInterest) + inviteFriendReward,
+              purchasedNFT * (usdcPerNft + nftInterest) + inviteFriendReward,
             )}
             <span> USDC</span>
           </>

--- a/src/components/NFTDetails/NFTInfo.tsx
+++ b/src/components/NFTDetails/NFTInfo.tsx
@@ -86,7 +86,7 @@ const NFTInfo: React.FC<Props> = ({ type, interest, nftInfo }) => {
             {/* <td>{nftData(NFTTraitType.Principal, nftInfo)}</td> */}
             <td>$10</td>
             <th>{t('nftMarket.nftInfoTable.3')}</th>
-            <td>$0.39</td>
+            <td>${interest}</td>
           </tr>
           <tr>
             <th>{t('nftMarket.nftInfoTable.4')}</th>

--- a/src/components/NFTDetails/Purchase.tsx
+++ b/src/components/NFTDetails/Purchase.tsx
@@ -3,6 +3,8 @@ import { useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import Skeleton from 'react-loading-skeleton';
 import Arrow from 'src/assets/images/market/arrow.svg';
+import MediaQuery from 'src/enums/MediaQuery';
+import useMediaQueryType from 'src/hooks/useMediaQueryType';
 import { formatCommaSmallZeroDisits } from 'src/utiles/formatters';
 
 interface Props {
@@ -35,6 +37,8 @@ const Purchase: React.FC<Props> = ({
     second: 0,
   });
   const [unfoldProgress, setProgress] = useState(false);
+
+  const { value: mediaQuery } = useMediaQueryType();
 
   useLayoutEffect(() => {
     if (current.isAfter(endedTime)) {
@@ -122,7 +126,11 @@ const Purchase: React.FC<Props> = ({
         <section
           className="nft-details__purchase__progress-section"
           style={{
-            height: unfoldProgress ? 370 : 0,
+            height: unfoldProgress
+              ? mediaQuery === MediaQuery.PC
+                ? 370
+                : 300
+              : 0,
             paddingBottom: unfoldProgress ? 18 : 0,
           }}>
           {userTotalPurchase ? (
@@ -172,6 +180,7 @@ const Purchase: React.FC<Props> = ({
         </section>
         <section
           className="nft-details__purchase__footer"
+          style={{ cursor: 'pointer' }}
           onClick={() => setProgress(!unfoldProgress)}>
           <span
             className="nft-details__purchase__arrow"

--- a/src/components/NFTDetails/Purchase.tsx
+++ b/src/components/NFTDetails/Purchase.tsx
@@ -120,7 +120,11 @@ const Purchase: React.FC<Props> = ({
               max={totalAmount}
             />
           ) : (
-            <Skeleton width={530} height={10} style={{ marginTop: 10 }} />
+            <Skeleton
+              width={mediaQuery === MediaQuery.PC ? 530 : '100%'}
+              height={10}
+              style={{ marginTop: 10 }}
+            />
           )}
         </div>
         <section
@@ -174,7 +178,10 @@ const Purchase: React.FC<Props> = ({
               </section>
             </>
           ) : (
-            <Skeleton width={530} height={370} />
+            <Skeleton
+              width={mediaQuery === MediaQuery.PC ? 530 : '100%'}
+              height={370}
+            />
           )}
           <span>(* 1NFT = $10)</span>
         </section>

--- a/src/components/NFTDetails/Purchase.tsx
+++ b/src/components/NFTDetails/Purchase.tsx
@@ -98,32 +98,36 @@ const Purchase: React.FC<Props> = ({
         </div>
       </section>
       <section className="nft-details__purchase__round">
-        <h2>{t('nftMarket.purchasedDate')}</h2>
+        <section>
+          <h2>{t('nftMarket.purchasedDate')}</h2>
+        </section>
         <div>
           <div>
-            <b>{remainingTime.day.toString().padStart(2, '0')}</b>
-            <p>{t('nftMarket.timeUnit.0')}</p>
+            <div>
+              <b>{remainingTime.day.toString().padStart(2, '0')}</b>
+              <p>{t('nftMarket.timeUnit.0')}</p>
+            </div>
+            <b>:</b>
+            <div>
+              <b>{remainingTime.hour.toString().padStart(2, '0')}</b>
+              <p>{t('nftMarket.timeUnit.1')}</p>
+            </div>
+            <b>:</b>
+            <div>
+              <b>{remainingTime.minute.toString().padStart(2, '0')}</b>
+              <p>{t('nftMarket.timeUnit.2')}</p>
+            </div>
+            <b>:</b>
+            <div>
+              <b>{remainingTime.second.toString().padStart(2, '0')}</b>
+              <p>{t('nftMarket.timeUnit.3')}</p>
+            </div>
           </div>
-          <b>:</b>
-          <div>
-            <b>{remainingTime.hour.toString().padStart(2, '0')}</b>
-            <p>{t('nftMarket.timeUnit.1')}</p>
-          </div>
-          <b>:</b>
-          <div>
-            <b>{remainingTime.minute.toString().padStart(2, '0')}</b>
-            <p>{t('nftMarket.timeUnit.2')}</p>
-          </div>
-          <b>:</b>
-          <div>
-            <b>{remainingTime.second.toString().padStart(2, '0')}</b>
-            <p>{t('nftMarket.timeUnit.3')}</p>
-          </div>
+          <p>
+            {moment(startTime).format('YYYY.MM.DD HH:mm:ss')} ~{' '}
+            {moment(endedTime).format('YYYY.MM.DD HH:mm:ss')} KST
+          </p>
         </div>
-        <p>
-          {moment(startTime).format('YYYY.MM.DD HH:mm:ss')} ~{' '}
-          {moment(endedTime).format('YYYY.MM.DD HH:mm:ss')} KST
-        </p>
       </section>
     </>
   );

--- a/src/components/NFTDetails/Purchase.tsx
+++ b/src/components/NFTDetails/Purchase.tsx
@@ -11,6 +11,9 @@ interface Props {
   startTime: moment.Moment;
   endedTime: moment.Moment;
   etherscanLink: string;
+  offChainSellingAmount: number;
+  totalAmount: number;
+  usdcPerNft: number;
 }
 
 const Purchase: React.FC<Props> = ({
@@ -19,6 +22,9 @@ const Purchase: React.FC<Props> = ({
   startTime,
   endedTime,
   etherscanLink,
+  offChainSellingAmount,
+  totalAmount,
+  usdcPerNft,
 }) => {
   const { t } = useTranslation();
   const current = moment();
@@ -28,6 +34,7 @@ const Purchase: React.FC<Props> = ({
     minute: 0,
     second: 0,
   });
+  const [unfoldProgress, setProgress] = useState(false);
 
   useLayoutEffect(() => {
     if (current.isAfter(endedTime)) {
@@ -72,7 +79,7 @@ const Purchase: React.FC<Props> = ({
   return (
     <>
       <section className="nft-details__purchase__status">
-        <section>
+        <section className="nft-details__purchase__header">
           <h2>{t('nftMarket.currentPurchase')}</h2>
           <a href={etherscanLink} target="_blank">
             <img src={Arrow} alt="new tab icon" />
@@ -94,11 +101,58 @@ const Purchase: React.FC<Props> = ({
             <b>{formatCommaSmallZeroDisits(totalPurchase)}</b>
           </div>
           <progress value={userTotalPurchase} max={totalPurchase} />
-          <p>(* 1NFT = $10)</p>
         </div>
+        <section
+          className="nft-details__purchase__progress-section"
+          style={{
+            height: unfoldProgress ? 370 : 0,
+            paddingBottom: unfoldProgress ? 18 : 0,
+          }}>
+          <section>
+            <b>1. 오프체인 백커</b>
+            <div>
+              <div>
+                <p>판매 USD</p>
+                <p>총 USD</p>
+              </div>
+              <div>
+                <b>1234</b>
+                <b>5678</b>
+              </div>
+              <progress value={userTotalPurchase} max={totalPurchase} />
+            </div>
+          </section>
+          <section>
+            <b>2. 온체인 판매 현황</b>
+            <div>
+              <div>
+                <p>판매 NFT</p>
+                <p>총 NFT</p>
+              </div>
+              <div>
+                <b>1234</b>
+                <b>5678</b>
+              </div>
+              <progress value={userTotalPurchase} max={totalPurchase} />
+            </div>
+          </section>
+          <span>(* 1NFT = $10)</span>
+        </section>
+        <section
+          className="nft-details__purchase__footer"
+          onClick={() => setProgress(!unfoldProgress)}>
+          <span
+            className="nft-details__purchase__arrow"
+            style={{
+              transform: unfoldProgress ? 'rotate(-45deg)' : 'rotate(135deg)',
+              marginBottom: unfoldProgress ? -4 : 9,
+            }}
+          />
+        </section>
       </section>
+
       <section className="nft-details__purchase__round">
-        <section>
+        <section className="nft-details__purchase__header">
           <h2>{t('nftMarket.purchasedDate')}</h2>
         </section>
         <div>
@@ -123,11 +177,14 @@ const Purchase: React.FC<Props> = ({
               <p>{t('nftMarket.timeUnit.3')}</p>
             </div>
           </div>
+        </div>
+
+        <section className="nft-details__purchase__footer">
           <p>
             {moment(startTime).format('YYYY.MM.DD HH:mm:ss')} ~{' '}
             {moment(endedTime).format('YYYY.MM.DD HH:mm:ss')} KST
           </p>
-        </div>
+        </section>
       </section>
     </>
   );

--- a/src/components/NFTDetails/Purchase.tsx
+++ b/src/components/NFTDetails/Purchase.tsx
@@ -87,8 +87,8 @@ const Purchase: React.FC<Props> = ({
         </section>
         <div>
           <div>
-            <p>{t('nftMarket.purchasedNTF')}</p>
-            <p>{t('nftMarket.totalPurchased')}</p>
+            <p>{t('nftMarket.sellingUSD')}</p>
+            <p>{t('nftMarket.totalSellingUSD')}</p>
           </div>
           <div>
             <b>
@@ -128,11 +128,11 @@ const Purchase: React.FC<Props> = ({
           {userTotalPurchase ? (
             <>
               <section>
-                <b>1. 오프체인 백커</b>
+                <b>1. {t('nftMarket.offChainBackers')}</b>
                 <div>
                   <div>
-                    <p>판매 USD</p>
-                    <p>총 USD</p>
+                    <p>{t('nftMarket.sellingUSD')}</p>
+                    <p>{t('nftMarket.totalSellingUSD')}</p>
                   </div>
                   <div>
                     <b>{formatCommaSmallZeroDisits(offChainSellingAmount)}</b>
@@ -145,11 +145,11 @@ const Purchase: React.FC<Props> = ({
                 </div>
               </section>
               <section>
-                <b>2. 온체인 판매 현황</b>
+                <b>2. {t('nftMarket.onChainPurchased')}</b>
                 <div>
                   <div>
-                    <p>판매 NFT</p>
-                    <p>총 NFT</p>
+                    <p>{t('nftMarket.purchasedNTF')}</p>
+                    <p>{t('nftMarket.totalPurchased')}</p>
                   </div>
                   <div>
                     <b>

--- a/src/components/NFTDetails/Purchase.tsx
+++ b/src/components/NFTDetails/Purchase.tsx
@@ -92,15 +92,32 @@ const Purchase: React.FC<Props> = ({
           </div>
           <div>
             <b>
-              {userTotalPurchase || userTotalPurchase === 0 ? (
-                formatCommaSmallZeroDisits(userTotalPurchase)
+              {userTotalPurchase ? (
+                formatCommaSmallZeroDisits(
+                  offChainSellingAmount + userTotalPurchase * usdcPerNft,
+                )
               ) : (
-                <Skeleton width={60} height={15} />
+                <Skeleton width={100} height={20} />
               )}
             </b>
-            <b>{formatCommaSmallZeroDisits(totalPurchase)}</b>
+            <b>
+              {userTotalPurchase ? (
+                formatCommaSmallZeroDisits(totalAmount)
+              ) : (
+                <Skeleton width={100} height={20} />
+              )}
+            </b>
           </div>
-          <progress value={userTotalPurchase} max={totalPurchase} />
+          {userTotalPurchase ? (
+            <progress
+              value={
+                offChainSellingAmount + (userTotalPurchase || 0) * usdcPerNft
+              }
+              max={totalAmount}
+            />
+          ) : (
+            <Skeleton width={530} height={10} style={{ marginTop: 10 }} />
+          )}
         </div>
         <section
           className="nft-details__purchase__progress-section"
@@ -108,34 +125,49 @@ const Purchase: React.FC<Props> = ({
             height: unfoldProgress ? 370 : 0,
             paddingBottom: unfoldProgress ? 18 : 0,
           }}>
-          <section>
-            <b>1. 오프체인 백커</b>
-            <div>
-              <div>
-                <p>판매 USD</p>
-                <p>총 USD</p>
-              </div>
-              <div>
-                <b>1234</b>
-                <b>5678</b>
-              </div>
-              <progress value={userTotalPurchase} max={totalPurchase} />
-            </div>
-          </section>
-          <section>
-            <b>2. 온체인 판매 현황</b>
-            <div>
-              <div>
-                <p>판매 NFT</p>
-                <p>총 NFT</p>
-              </div>
-              <div>
-                <b>1234</b>
-                <b>5678</b>
-              </div>
-              <progress value={userTotalPurchase} max={totalPurchase} />
-            </div>
-          </section>
+          {userTotalPurchase ? (
+            <>
+              <section>
+                <b>1. 오프체인 백커</b>
+                <div>
+                  <div>
+                    <p>판매 USD</p>
+                    <p>총 USD</p>
+                  </div>
+                  <div>
+                    <b>{formatCommaSmallZeroDisits(offChainSellingAmount)}</b>
+                    <b>{formatCommaSmallZeroDisits(offChainSellingAmount)}</b>
+                  </div>
+                  <progress
+                    value={offChainSellingAmount}
+                    max={offChainSellingAmount}
+                  />
+                </div>
+              </section>
+              <section>
+                <b>2. 온체인 판매 현황</b>
+                <div>
+                  <div>
+                    <p>판매 NFT</p>
+                    <p>총 NFT</p>
+                  </div>
+                  <div>
+                    <b>
+                      {userTotalPurchase || userTotalPurchase === 0 ? (
+                        formatCommaSmallZeroDisits(userTotalPurchase)
+                      ) : (
+                        <Skeleton width={60} height={15} />
+                      )}
+                    </b>
+                    <b>{formatCommaSmallZeroDisits(totalPurchase)}</b>
+                  </div>
+                  <progress value={userTotalPurchase} max={totalPurchase} />
+                </div>
+              </section>
+            </>
+          ) : (
+            <Skeleton width={530} height={370} />
+          )}
           <span>(* 1NFT = $10)</span>
         </section>
         <section

--- a/src/components/NFTDetails/index.tsx
+++ b/src/components/NFTDetails/index.tsx
@@ -116,9 +116,11 @@ const NFTDetails = (): JSX.Element => {
     `https://opensea.io/assets/ethereum/${envs.market.nftAddress}/${i}`;
   const etherscanLink = `https://etherscan.io/address/${envs.market.controllerAddress}`;
 
-  const totalPurchase = 54000;
-  const nftInterest = 0.39;
-  const nftPerUsdc = 10;
+  const TOTAL_NFT_PURCHASE = 54000;
+  const NFT_INTEREST = 0.39;
+  const USDC_PER_NFT = 10;
+  const OFF_CHAIN_SELLING_AMOUNT = 560000;
+  const TOTAL_AMOUNT = 1100000;
 
   const startTime = moment(
     '2022.07.21 20:00:00 +9:00',
@@ -220,9 +222,9 @@ const NFTDetails = (): JSX.Element => {
     )
       ? (advanceReservation.includes(account || '') ||
           current.isBetween(startTime, endedTime)) &&
-          totalPurchase > (nftTotalSupply || 0)
+          TOTAL_NFT_PURCHASE > (nftTotalSupply || 0)
       : false;
-  }, [nftTotalSupply, current, totalPurchase]);
+  }, [nftTotalSupply, current, TOTAL_NFT_PURCHASE]);
 
   const getPurchasedNFT = useCallback(async () => {
     try {
@@ -308,7 +310,7 @@ const NFTDetails = (): JSX.Element => {
           <section className="nft-details__nft-info">
             <NFTInfo
               type={t('market.nftType.0')}
-              interest={nftInterest}
+              interest={NFT_INTEREST}
               nftInfo={nftInfo}
             />
           </section>
@@ -431,7 +433,7 @@ const NFTDetails = (): JSX.Element => {
         <NFTPurchaseModal
           modalClose={() => setModalType('')}
           balances={balances}
-          remainingNFT={totalPurchase - (nftTotalSupply || 0)}
+          remainingNFT={TOTAL_NFT_PURCHASE - (nftTotalSupply || 0)}
           btnLocation={btnLocation}
         />
       ) : modalType === 'changeNetwork' ? (
@@ -494,7 +496,7 @@ const NFTDetails = (): JSX.Element => {
         <InvestRewardModal
           onClose={() => setModalType('')}
           holdingNft={purchasedNFT || 0}
-          nftPerUsdc={nftPerUsdc}
+          usdcPerNft={USDC_PER_NFT}
         />
       ) : (
         <></>
@@ -540,18 +542,21 @@ const NFTDetails = (): JSX.Element => {
             openseaLink={openSeaLink(0)}
             rewardTitle={'나의 예상 수익금'}
             isMoneypoolCharged={false}
-            nftPerUsdc={nftPerUsdc}
-            nftInterest={nftInterest}
+            usdcPerNft={USDC_PER_NFT}
+            nftInterest={NFT_INTEREST}
             inviteFriendReward={0}
           />
         </article>
         <article className="nft-details__purchase">
           <Purchase
             userTotalPurchase={nftTotalSupply || 0}
-            totalPurchase={totalPurchase}
+            totalPurchase={TOTAL_NFT_PURCHASE}
             startTime={startTime}
             endedTime={endedTime}
             etherscanLink={etherscanLink}
+            offChainSellingAmount={OFF_CHAIN_SELLING_AMOUNT}
+            totalAmount={TOTAL_AMOUNT}
+            usdcPerNft={USDC_PER_NFT}
           />
         </article>
         <article className="nft-details__content">

--- a/src/components/NFTDetails/index.tsx
+++ b/src/components/NFTDetails/index.tsx
@@ -123,6 +123,9 @@ const NFTDetails = (): JSX.Element => {
   const TOTAL_AMOUNT = 1100000;
   const USER_EVENT_REWARD = 0;
 
+  const IS_FRIEND_EVENT_START = false;
+  const IS_MONEY_POOL_CHARGED = false;
+
   const startTime = moment(
     '2022.07.21 20:00:00 +9:00',
     'YYYY.MM.DD hh:mm:ss Z',
@@ -500,6 +503,7 @@ const NFTDetails = (): JSX.Element => {
           usdcPerNft={USDC_PER_NFT}
           eventReward={USER_EVENT_REWARD}
           nftInterest={NFT_INTEREST}
+          onSubmit={() => {}}
         />
       ) : (
         <></>
@@ -543,8 +547,12 @@ const NFTDetails = (): JSX.Element => {
             isDisabled={purchaseButtonDisable}
             mainnetType={mainnetType}
             openseaLink={openSeaLink(0)}
-            rewardTitle={'나의 예상 수익금'}
-            isMoneypoolCharged={false}
+            rewardTitle={
+              IS_MONEY_POOL_CHARGED
+                ? t('nftMarket.expectedRewardTitle')
+                : t('nftMarket.rewardTitle')
+            }
+            isMoneypoolCharged={IS_MONEY_POOL_CHARGED}
             usdcPerNft={USDC_PER_NFT}
             nftInterest={NFT_INTEREST}
             inviteFriendReward={USER_EVENT_REWARD}

--- a/src/components/NFTDetails/index.tsx
+++ b/src/components/NFTDetails/index.tsx
@@ -494,16 +494,23 @@ const NFTDetails = (): JSX.Element => {
           &nbsp;&gt;&nbsp;
           <p>{t('nftMarket.title')}</p>
         </div>
-        <Link
-          className="nft-details__guide pc-only"
-          to={{
-            pathname: `/${lng}/market/guide`,
-          }}>
-          {t('nftMarket.guide')}
-        </Link>
         <article className="nft-details__header" ref={headerRef}>
+          <div>
+            <h1>{t('nftMarket.title')}</h1>
+            <p>{t('nftMarket.subTitle')}</p>
+          </div>
+        </article>
+        <article className="nft-details__current-nfts">
+          <Link
+            className="nft-details__guide pc-only"
+            to={{
+              pathname: `/${lng}/market/guide`,
+            }}>
+            {t('nftMarket.guide')}
+          </Link>
           <Header
             onButtonClick={() => purchaseButtonAction('TopButton')}
+            onRewardButtonClick={() => {}}
             purchasedNFT={purchasedNFT}
             isDisabled={purchaseButtonDisable}
             mainnetType={mainnetType}

--- a/src/components/NFTDetails/index.tsx
+++ b/src/components/NFTDetails/index.tsx
@@ -121,6 +121,7 @@ const NFTDetails = (): JSX.Element => {
   const USDC_PER_NFT = 10;
   const OFF_CHAIN_SELLING_AMOUNT = 560000;
   const TOTAL_AMOUNT = 1100000;
+  const USER_EVENT_REWARD = 0;
 
   const startTime = moment(
     '2022.07.21 20:00:00 +9:00',
@@ -497,6 +498,8 @@ const NFTDetails = (): JSX.Element => {
           onClose={() => setModalType('')}
           holdingNft={purchasedNFT || 0}
           usdcPerNft={USDC_PER_NFT}
+          eventReward={USER_EVENT_REWARD}
+          nftInterest={NFT_INTEREST}
         />
       ) : (
         <></>
@@ -544,7 +547,7 @@ const NFTDetails = (): JSX.Element => {
             isMoneypoolCharged={false}
             usdcPerNft={USDC_PER_NFT}
             nftInterest={NFT_INTEREST}
-            inviteFriendReward={0}
+            inviteFriendReward={USER_EVENT_REWARD}
           />
         </article>
         <article className="nft-details__purchase">

--- a/src/components/NFTDetails/index.tsx
+++ b/src/components/NFTDetails/index.tsx
@@ -117,6 +117,8 @@ const NFTDetails = (): JSX.Element => {
   const etherscanLink = `https://etherscan.io/address/${envs.market.controllerAddress}`;
 
   const totalPurchase = 54000;
+  const nftInterest = 0.39;
+  const nftPerUsdc = 10;
 
   const startTime = moment(
     '2022.07.21 20:00:00 +9:00',
@@ -181,6 +183,20 @@ const NFTDetails = (): JSX.Element => {
       browserHeight,
       true,
     );
+  };
+
+  const rewardButtonAction = () => {
+    const wallet = sessionStorage.getItem('@connect');
+    // ReactGA.modalview('purchaseBondNft');
+    // setBtnLocation(location);
+
+    return account
+      ? mainnetType === MainnetType.Ethereum
+        ? setModalType('investmentReward')
+        : wallet === 'metamask'
+        ? setModalType('changeNetwork')
+        : setModalType('reconnect')
+      : setModalType('selectWallet');
   };
 
   const purchaseButtonAction = (location: string) => {
@@ -292,7 +308,7 @@ const NFTDetails = (): JSX.Element => {
           <section className="nft-details__nft-info">
             <NFTInfo
               type={t('market.nftType.0')}
-              interest={0.39}
+              interest={nftInterest}
               nftInfo={nftInfo}
             />
           </section>
@@ -474,8 +490,12 @@ const NFTDetails = (): JSX.Element => {
           tokenAmount={purchasedNFT ? (purchasedNFT * 10 * 0.01) / 0.01858 : 0}
           tokenName={'ELFI'}
         />
-      ) : modalType !== 'investmentReward' ? (
-        <InvestRewardModal onClose={() => setModalType('')} />
+      ) : modalType === 'investmentReward' ? (
+        <InvestRewardModal
+          onClose={() => setModalType('')}
+          holdingNft={purchasedNFT || 0}
+          nftPerUsdc={nftPerUsdc}
+        />
       ) : (
         <></>
       )}
@@ -513,11 +533,16 @@ const NFTDetails = (): JSX.Element => {
           </Link>
           <Header
             onButtonClick={() => purchaseButtonAction('TopButton')}
-            onRewardButtonClick={() => {}}
+            onRewardButtonClick={() => rewardButtonAction()}
             purchasedNFT={purchasedNFT}
             isDisabled={purchaseButtonDisable}
             mainnetType={mainnetType}
             openseaLink={openSeaLink(0)}
+            rewardTitle={'나의 예상 수익금'}
+            isMoneypoolCharged={false}
+            nftPerUsdc={nftPerUsdc}
+            nftInterest={nftInterest}
+            inviteFriendReward={0}
           />
         </article>
         <article className="nft-details__purchase">

--- a/src/components/NFTDetails/index.tsx
+++ b/src/components/NFTDetails/index.tsx
@@ -549,8 +549,8 @@ const NFTDetails = (): JSX.Element => {
             openseaLink={openSeaLink(0)}
             rewardTitle={
               IS_MONEY_POOL_CHARGED
-                ? t('nftMarket.expectedRewardTitle')
-                : t('nftMarket.rewardTitle')
+                ? t('nftMarket.rewardTitle')
+                : t('nftMarket.expectedRewardTitle')
             }
             isMoneypoolCharged={IS_MONEY_POOL_CHARGED}
             usdcPerNft={USDC_PER_NFT}

--- a/src/components/NFTDetails/index.tsx
+++ b/src/components/NFTDetails/index.tsx
@@ -67,6 +67,7 @@ import SelectWalletModal from '../Market/Modals/SelectWalletModal';
 import ReconnectWallet from '../Market/Modals/components/ReconnectWallet';
 import NewsCard from './NewsCard';
 import Guide from './Guide';
+import InvestRewardModal from '../Market/Modals/InvestmentRewardModal';
 
 export interface INews {
   title: string;
@@ -473,6 +474,8 @@ const NFTDetails = (): JSX.Element => {
           tokenAmount={purchasedNFT ? (purchasedNFT * 10 * 0.01) / 0.01858 : 0}
           tokenName={'ELFI'}
         />
+      ) : modalType !== 'investmentReward' ? (
+        <InvestRewardModal onClose={() => setModalType('')} />
       ) : (
         <></>
       )}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -44,7 +44,7 @@
             "content": "There is no limit on the amount of deposit, and even a small amount can be deposited in ELYFI"
           },
           {
-            "header": "No membership required",
+            "header": "No KYC required",
             "content": "There are no signup requirements, so anyone in the world can use it."
           },
           {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -823,6 +823,15 @@
       "currentPurchase": "Sales Status",
       "purchasedNTF": "Sold NFT",
       "totalPurchased": "Total NFT",
+      "sellingUSD": "Sold USD",
+      "totalSellingUSD": "Total USD",
+      "offChainBackers": "Off-chain Backers",
+      "onChainPurchased": "On-chain sales",
+      "expectedRewardTitle": "My expected profit",
+      "rewardTitle": "My profit",
+      "expectedContent": "My expected profit represents the proceeds that can be received from the bond NFTs held by them.\nActual profit may differ from expected profit because interest changes depending on the repayment date.",
+      "contentAfterEvent": "My expected profit represents the proceeds that can be received from the bond NFTs held by them.\nIf you participate in a friend invitation event, the event reward is included in the profit.\nActual profit may differ from expected profit because interest changes depending on the repayment date.",
+      "claim": "Claim",
       "purchasedDate": "Sales Period",
       "timeUnit": ["Days", "Hours", "Minutes", "Seconds"],
       "productPointTitle": "Product appealing points",
@@ -1041,6 +1050,15 @@
         "header": "Congratulations!<br />You have accumulated<br/> {{tokenAmount}} {{tokenName}} tokens so far.",
         "title": "ELFI token payment date",
         "content": "Twitter posts must not be deleted until token disbursements are complete.<br/>In addition, the quantity of ELFI tokens is calculated based on<br/> the ELFI price of $0.01858 on July 21, 2022 KST."
+      },
+      "reward": {
+        "title": "Claim profit",
+        "currentHolding": "My holdings",
+        "content": "* When the profit are received, all NFTs will be burned.",
+        "currentReward": "My profit",
+        "repayment": "Repayment",
+        "eventReward": "Reward",
+        "claim": "Claim"
       }
     }
   }

--- a/src/i18n/ko.json
+++ b/src/i18n/ko.json
@@ -789,9 +789,18 @@
         "invalidNetwork": "지갑에서 이더리움 네트워크로 연결해주세요."
       },
       "currentPurchase": "판매 현황",
-      "purchasedNTF": "판매된 NFT",
+      "purchasedNTF": "판매 NFT",
       "totalPurchased": "총 NFTs",
+      "sellingUSD": "판매 USD",
+      "totalSellingUSD": "총 USD",
+      "offChainBackers": "오프체인 Backers",
+      "onChainPurchased": "온체인 판매 현황",
       "purchasedDate": "판매 기간",
+      "expectedRewardTitle": "나의 예상 수익금",
+      "rewardTitle": "나의 수익금",
+      "expectedContent": "나의 예상 수익금은 보유한 채권 NFT로 수령할 수 있는 수익금을 나타냅니다.\n상환일에 따라 이자가 변경되기 때문에 실제 수익금이 예상 수익금과 달라질 수 있습니다.",
+      "contentAfterEvent": "나의 예상 수익금은 보유한 채권 NFT로 수령할 수 있는 수익금을 나타냅니다.\n친구 초대 이벤트에 참여한 경우에는 해당 수익금에 이벤트 보상이 포함됩니다.\n또한 상환일에 따라 이자가 변경되기 때문에 실제 수익금이 예상 수익금과 달라질 수 있습니다.",
+      "claim": "수령하기",
       "timeUnit": ["일", "시간", "분", "초"],
       "productPointTitle": "상품 매력 포인트",
       "productPoint": {
@@ -1001,6 +1010,15 @@
         "header": "축하합니다!<br />지금까지 {{tokenName}} 토큰 {{tokenAmount}}개를 적립했습니다.",
         "title": "ELFI 토큰 지급일",
         "content": "토큰 지급 완료 시점까지 트위터 게시물이 유지돼야 합니다.<br/>또한 ELFI 토큰 수량은 2022년 7월 21일(KST) ELFI의 가격인<br/> $0.01858를 기준으로 산정합니다."
+      },
+      "reward": {
+        "title": "수익금 수령하기",
+        "currentHolding": "나의 보유 수량",
+        "content": "* 수익금 수령 시, 해당 NFT는 전부 소각됩니다.",
+        "currentReward": "나의 수익금",
+        "repayment": "상환금",
+        "eventReward": "이벤트 보상",
+        "claim": "수령하기"
       }
     }
   }

--- a/src/stylesheet/mobile.scss
+++ b/src/stylesheet/mobile.scss
@@ -1976,9 +1976,63 @@ $bold: 'Inter-Bold', 'Montserrat-bold';
       margin-top: 50px;
       padding: 12px 15px;
     }
+    &__current-nfts {
+      > article {
+        flex-direction: column;
+        background-color: initial;
+        box-shadow: none;
+        margin-top: 10px;
+        border-radius: 0;
+        width: 100%;
+        > section {
+          background-color: #ffffff;
+          box-shadow: 0px 0px 6px #00000029;
+          margin-top: 10px;
+          border-radius: 10px;
+          &:last-child {
+            border-left: none;
+            margin-top: 20px;
+          }
+          > div {
+            padding: 12px 15px;
+            > b {
+              font-size: 12px;
+              > span {
+                margin-left: 5px;
+              }
+            }
+          }
+          > section {
+            height: initial;
+            > b {
+              margin-top: 22px;
+              font-size: 18px;
+              padding-right: 15px;
+            }
+            > section {
+              display: flex;
+              flex-direction: column;
+              margin: 25px 15px 15px;
+              gap: 10px;
+              > a {
+                width: 100%;
+                height: 26px;
+                font-size: 12px;
+                line-height: 26px;
+              }
+              > button {
+                width: 100%;
+                height: 26px;
+                font-size: 12px;
+                line-height: 26px;
+              }
+            }
+          }
+        }
+      }
+    }
     &__purchase {
-      margin-top: 50px;
-      padding: 12px 15px;
+      margin-top: 20px;
       flex-direction: column;
       align-items: center;
       > section {
@@ -1986,7 +2040,7 @@ $bold: 'Inter-Bold', 'Montserrat-bold';
         padding: 0 !important;
         width: 100%;
         > section {
-          margin-bottom: 15px;
+          padding: 12px 15px;
           > h2 {
             font-size: 12px;
           }
@@ -2000,6 +2054,7 @@ $bold: 'Inter-Bold', 'Montserrat-bold';
       }
       &__status {
         > div {
+          padding: 12px 15px;
           > div {
             > p {
               font-size: 10px;
@@ -2027,32 +2082,33 @@ $bold: 'Inter-Bold', 'Montserrat-bold';
       }
       &__round {
         > div {
-          display: flex;
-          flex-direction: row;
-          justify-content: space-evenly;
-          > b {
-            font-size: 20px;
-            color: $font-color;
-          }
+          padding: 12px 15px;
           > div {
             display: flex;
-            flex-direction: column;
-            align-items: center;
-            margin-bottom: 15px;
+            flex-direction: row;
+            justify-content: space-evenly;
             > b {
               font-size: 20px;
               color: $font-color;
             }
-            > p {
-              font-size: 12px;
-              color: #707070;
+            > div {
+              display: flex;
+              flex-direction: column;
+              align-items: center;
+              margin-bottom: 15px;
+              > b {
+                font-size: 20px;
+                color: $font-color;
+              }
+              > p {
+                font-size: 12px;
+                color: #707070;
+              }
             }
           }
-        }
-        > p {
-          font-size: 10px;
-          color: #333333;
-          text-align: right;
+          > p {
+            padding: 0;
+          }
         }
       }
     }

--- a/src/stylesheet/mobile.scss
+++ b/src/stylesheet/mobile.scss
@@ -2037,21 +2037,63 @@ $bold: 'Inter-Bold', 'Montserrat-bold';
       margin-top: 20px;
       flex-direction: column;
       align-items: center;
+      &__header {
+        padding: 12px 15px;
+        > h2 {
+          font-size: 12px;
+        }
+      }
+      &__progress-section {
+        padding: 0 15px;
+        > section {
+          margin-top: 20px;
+          > b {
+            font-size: 12px;
+          }
+          > div {
+            margin-top: 10px;
+            padding: 12px 15px;
+            border: 1px solid #e6e6e6;
+            border-radius: 10px;
+            > div {
+              display: flex;
+              flex-direction: row;
+              align-items: center;
+              width: 100%;
+              justify-content: space-between;
+              > p {
+                color: #707070;
+                font-size: 10px;
+              }
+              > b {
+                font-size: 12px;
+                color: #333333;
+              }
+            }
+          }
+        }
+        > span {
+          font-size: 10px;
+          display: block;
+          text-align: right;
+          color: $gray-font-color;
+          margin-top: 8px;
+        }
+      }
+      &__footer {
+        height: 30px;
+        > p {
+          margin: 9px;
+          color: #333333;
+          font-size: 10px;
+        }
+      }
       > section {
         flex: 1;
         padding: 0 !important;
         width: 100%;
-        > section {
-          padding: 12px 15px;
-          > h2 {
-            font-size: 12px;
-          }
-        }
-        > h2 {
-          font-size: 12px;
-        }
-        &:last-child {
-          border-left: none;
+        > div {
+          height: initial;
         }
       }
       &__status {
@@ -2097,13 +2139,13 @@ $bold: 'Inter-Bold', 'Montserrat-bold';
               display: flex;
               flex-direction: column;
               align-items: center;
-              margin-bottom: 15px;
+              margin-bottom: 0px;
               > b {
                 font-size: 20px;
                 color: $font-color;
               }
               > p {
-                font-size: 12px;
+                font-size: 10px;
                 color: #707070;
               }
             }
@@ -5630,6 +5672,70 @@ $bold: 'Inter-Bold', 'Montserrat-bold';
       }
       > p {
         font-size: 11px;
+      }
+    }
+    &__investment-reward {
+      &__burn {
+        padding: 12px 15px;
+        > b {
+          font-size: 12px;
+        }
+        > div {
+          margin-top: 13px;
+          width: 100%;
+          border-radius: 10px;
+          padding: 12x 15px;
+          > b {
+            font-size: 25px;
+            > span {
+              font-size: 20px;
+            }
+          }
+          margin-bottom: 10px;
+        }
+        > p {
+          font-size: 10px;
+        }
+      }
+      &__current {
+        padding: 12px 15px;
+        > div {
+          > b {
+            font-size: 12px;
+            > span {
+              margin-left: 3px;
+              color: #646464;
+            }
+          }
+        }
+        > section {
+          border-radius: 10px;
+          padding: 12px 15px;
+          > div {
+            > p {
+              font-size: 12px;
+              color: $font-color;
+              > span {
+                margin-left: 5px;
+              }
+            }
+          }
+        }
+      }
+      &__button {
+        display: flex;
+        > button {
+          flex: 1;
+          height: 30px;
+          margin: 12px;
+          background: #00bfff;
+          border-radius: 35px;
+          cursor: pointer;
+          font-size: 12px;
+          line-height: 30px;
+          color: #fff;
+          border: 0;
+        }
       }
     }
   }

--- a/src/stylesheet/mobile.scss
+++ b/src/stylesheet/mobile.scss
@@ -1832,7 +1832,9 @@ $bold: 'Inter-Bold', 'Montserrat-bold';
             &::after {
               content: '';
               width: 300px;
+              height: 300px;
               background: #00000013;
+              border-radius: 5px;
             }
           }
           > section {

--- a/src/stylesheet/public.scss
+++ b/src/stylesheet/public.scss
@@ -2116,7 +2116,7 @@ input[type='number'] {
 
   .nft-details {
     &__guide {
-      margin-top: 30px;
+      margin-top: 120px;
       color: #00bfff;
       text-align: right;
       display: block;
@@ -2140,78 +2140,94 @@ input[type='number'] {
           color: $font-color;
         }
       }
-      > section {
-        width: 597px;
-        height: 135px;
-        box-shadow: 0px 0px 6px #00000029;
-        border-radius: 5px;
-        padding: 28px;
+    }
+    &__current-nfts {
+      > article {
+        display: flex;
         background-color: #ffffff;
-        > div {
-          display: flex;
-          flex-direction: row;
-          align-items: center;
-          justify-content: space-between;
-          margin-bottom: 27px;
-          > b {
-            font-size: 18px;
-            > span {
-              margin-left: 5px;
-              cursor: pointer;
+        box-shadow: 0px 0px 6px #00000029;
+        margin-top: 10px;
+        border-radius: 10px;
+        > section {
+          flex: 1;
+          &:last-child {
+            border-left: 1px solid #e6e6e6;
+          }
+          > div {
+            display: flex;
+            padding: 18px 0px 11px 28px;
+            border-bottom: 1px solid #e6e6e6;
+            flex-direction: row;
+            align-items: center;
+            > b {
+              font-size: 18px;
+              color: $font-color;
+              > span {
+                margin-left: 7px;
+              }
             }
           }
-        }
-        > b {
-          font-size: 20px;
-          color: $font-color;
-          text-align: right;
-          display: block;
-          &.null {
-            color: #888;
-          }
-        }
-        > section {
-          display: flex;
-          gap: 30px;
-          > a {
-            @include hover__box-shadow;
-            width: 130px;
-            height: 30px;
-            background: #3679b5;
-            border-radius: 15px;
-            cursor: pointer;
-            font-size: 15px;
-            color: #fff;
-            border: 0;
-            display: block;
-            flex: 1;
-            text-align: center;
-            line-height: 30px;
-          }
-          > button {
-            @include hover__box-shadow;
-            width: 130px;
-            height: 30px;
-            background: #00bfff;
-            border-radius: 15px;
-            cursor: pointer;
-            font-size: 15px;
-            color: #fff;
-            border: 0;
-            flex: 1;
-            &.disabled {
-              pointer-events: none;
-              cursor: not-allowed;
-              background-color: #f0f0f1;
+          > section {
+            height: 125px;
+            display: flex;
+            flex-direction: column;
+            justify-content: space-between;
+            > b {
+              margin-top: 22px;
+              font-size: 25px;
               color: $font-color;
+              text-align: right;
+              padding-right: 30px;
+              display: block;
+              > span {
+                color: #646464;
+              }
+            }
+            > section {
+              display: flex;
+              gap: 30px;
+              margin: 21px auto 19px;
+              > a {
+                @include hover__box-shadow;
+                width: 250px;
+                height: 30px;
+                background: #3679b5;
+                border-radius: 15px;
+                cursor: pointer;
+                font-size: 15px;
+                color: #fff;
+                border: 0;
+                line-height: 30px;
+                align-items: center;
+                display: flex;
+                text-align: center;
+                justify-content: center;
+                gap: 5px;
+              }
+              > button {
+                @include hover__box-shadow;
+                width: 250px;
+                height: 30px;
+                background: #00bfff;
+                border-radius: 15px;
+                cursor: pointer;
+                font-size: 15px;
+                color: #fff;
+                border: 0;
+                &.disabled {
+                  pointer-events: none;
+                  cursor: not-allowed;
+                  background-color: #f0f0f1;
+                  color: $font-color;
+                }
+              }
             }
           }
         }
       }
     }
-
     &__content {
-      margin-top: 15px;
+      margin-top: 20px;
       padding: 40px 30px;
       background-color: #fff;
       box-shadow: 0px 0px 6px #00000029;
@@ -2222,36 +2238,27 @@ input[type='number'] {
       flex-direction: row;
       align-items: center;
       justify-content: space-between;
-      margin-top: 60px;
-      padding: 40px 30px;
-      background-color: #fff;
-      box-shadow: 0px 0px 6px #00000029;
-      border-radius: 5px;
+      margin-top: 20px;
+      gap: 20px;
       > section {
         flex: 1;
-        > h2 {
-          font-size: 18px;
-          color: $font-color;
-          margin-bottom: 25px;
-        }
-        &:not(:last-child) {
-          padding-right: 40px;
-        }
-        &:last-child {
-          border-left: 1px solid #e6e6e6;
-          padding-left: 30px;
-        }
-      }
-      &__status {
+        width: 585px;
+        height: 180px;
+        border-radius: 10px;
+        box-shadow: 0px 0px 6px #00000029;
+        background-color: #fff;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
         > section {
           display: flex;
+          padding: 18px 0px 11px 28px;
+          border-bottom: 1px solid #e6e6e6;
           flex-direction: row;
-          margin-bottom: 25px;
           align-items: center;
           > h2 {
             font-size: 18px;
             color: $font-color;
-            margin-right: 8px;
           }
           > a {
             position: relative;
@@ -2264,17 +2271,20 @@ input[type='number'] {
             }
           }
         }
+      }
+      &__status {
         > div {
+          padding: 18px 28px;
           > div {
             display: flex;
             flex-direction: row;
             justify-content: space-between;
             > p {
               color: #707070;
-              font-size: 13px;
+              font-size: 15px;
             }
             > b {
-              font-size: 15px;
+              font-size: 18px;
               color: #333333;
             }
           }
@@ -2312,33 +2322,37 @@ input[type='number'] {
       }
       &__round {
         > div {
-          display: flex;
-          flex-direction: row;
-          justify-content: space-evenly;
-          > b {
-            font-size: 30px;
-            color: $font-color;
-          }
+          padding: 18px 28px 18px;
           > div {
             display: flex;
-            flex-direction: column;
-            align-items: center;
-            margin-bottom: 10px;
-            width: 44px;
+            flex-direction: row;
+            justify-content: space-evenly;
             > b {
               font-size: 30px;
               color: $font-color;
             }
-            > p {
-              font-size: 13px;
-              color: #707070;
+            > div {
+              display: flex;
+              flex-direction: column;
+              align-items: center;
+              margin-bottom: 10px;
+              width: 44px;
+              > b {
+                font-size: 30px;
+                color: $font-color;
+              }
+              > p {
+                font-size: 13px;
+                color: #707070;
+              }
             }
           }
-        }
-        > p {
-          font-size: 10px;
-          color: #333333;
-          text-align: right;
+          > p {
+            font-size: 10px;
+            color: #333333;
+            text-align: right;
+            padding-right: 10px;
+          }
         }
       }
     }

--- a/src/stylesheet/public.scss
+++ b/src/stylesheet/public.scss
@@ -2308,13 +2308,13 @@ input[type='number'] {
                 background: #e6e6e6;
               }
               &::-webkit-progress-value {
-                background: #0099cc;
+                background: #3c70e5;
                 border: 0;
                 border-radius: 10px;
                 height: 10px;
               }
               &::-moz-progress-bar {
-                background: #0099cc;
+                background: #3c70e5;
                 border: 0;
                 height: 10px;
                 border-radius: 10px;

--- a/src/stylesheet/public.scss
+++ b/src/stylesheet/public.scss
@@ -2252,6 +2252,7 @@ input[type='number'] {
           color: $font-color;
         }
         > a {
+          margin-left: 7px;
           position: relative;
           cursor: pointer;
           > img {

--- a/src/stylesheet/public.scss
+++ b/src/stylesheet/public.scss
@@ -2236,40 +2236,134 @@ input[type='number'] {
     &__purchase {
       display: flex;
       flex-direction: row;
-      align-items: center;
+      align-items: flex-start;
       justify-content: space-between;
       margin-top: 20px;
       gap: 20px;
+      &__header {
+        display: flex;
+        padding: 18px 0px 11px 28px;
+        border-bottom: 1px solid #e6e6e6;
+        flex-direction: row;
+        align-items: center;
+        height: initial !important;
+        > h2 {
+          font-size: 18px;
+          color: $font-color;
+        }
+        > a {
+          position: relative;
+          cursor: pointer;
+          > img {
+            position: absolute;
+            top: -10px;
+            width: 18px;
+            height: 18px;
+          }
+        }
+      }
+      &__progress-section {
+        padding: 0 28px;
+        padding-bottom: 18px;
+        border-top: 1px solid #e6e6e6;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+        transition: all 0.3s ease-in;
+        > section {
+          margin-top: 24px;
+          > b {
+            font-size: 18px;
+          }
+          > div {
+            margin-top: 10px;
+            padding: 21px;
+            border: 1px solid #e6e6e6;
+            border-radius: 10px;
+            > div {
+              display: flex;
+              flex-direction: row;
+              align-items: center;
+              width: 100%;
+              justify-content: space-between;
+              > p {
+                color: #707070;
+                font-size: 15px;
+              }
+              > b {
+                font-size: 18px;
+                color: #333333;
+              }
+            }
+            > progress {
+              width: 100%;
+              margin-top: 10px;
+              height: 10px;
+              border: 0;
+              vertical-align: 0;
+              &::-webkit-progress-bar {
+                height: 10px;
+                border-radius: 10px;
+                border: 0;
+                background: #e6e6e6;
+              }
+              &::-webkit-progress-value {
+                background: #0099cc;
+                border: 0;
+                border-radius: 10px;
+                height: 10px;
+              }
+              &::-moz-progress-bar {
+                background: #0099cc;
+                border: 0;
+                height: 10px;
+                border-radius: 10px;
+              }
+            }
+          }
+        }
+        > span {
+          font-size: 10px;
+          display: block;
+          text-align: right;
+          color: $gray-font-color;
+          margin-top: 8px;
+        }
+      }
+      &__footer {
+        border-top: 1px solid #e6e6e6;
+        height: 38px;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        cursor: pointer;
+        > p {
+          margin: 9px;
+          color: #333333;
+          font-size: 15px;
+        }
+      }
+      &__arrow {
+        display: inline-block;
+        width: 13px;
+        height: 13px;
+        border-top: 2px solid #3d81db;
+        border-right: 2px solid #3d81db;
+        text-align: center;
+        transition: all 0.3s ease-in;
+      }
       > section {
         flex: 1;
         width: 585px;
-        height: 180px;
+        height: initial;
         border-radius: 10px;
         box-shadow: 0px 0px 6px #00000029;
         background-color: #fff;
         display: flex;
         flex-direction: column;
         justify-content: space-between;
-        > section {
-          display: flex;
-          padding: 18px 0px 11px 28px;
-          border-bottom: 1px solid #e6e6e6;
-          flex-direction: row;
-          align-items: center;
-          > h2 {
-            font-size: 18px;
-            color: $font-color;
-          }
-          > a {
-            position: relative;
-            cursor: pointer;
-            > img {
-              position: absolute;
-              top: -10px;
-              width: 18px;
-              height: 18px;
-            }
-          }
+        > div {
+          height: 114px;
         }
       }
       &__status {
@@ -2313,11 +2407,6 @@ input[type='number'] {
               border-radius: 10px;
             }
           }
-          > p {
-            text-align: right;
-            color: #888;
-            font-size: 10px;
-          }
         }
       }
       &__round {
@@ -2346,12 +2435,6 @@ input[type='number'] {
                 color: #707070;
               }
             }
-          }
-          > p {
-            font-size: 10px;
-            color: #333333;
-            text-align: right;
-            padding-right: 10px;
           }
         }
       }

--- a/src/stylesheet/public.scss
+++ b/src/stylesheet/public.scss
@@ -176,7 +176,8 @@ $bold: 'Inter-Bold', 'SpoqaHanSansNeo-Bold', 'Montserrat-bold', 'Inter-Bold';
 }
 
 h1,
-h2 {
+h2,
+b {
   font-family: $bold;
   color: $font-color;
   font-weight: bold;

--- a/src/stylesheet/public.scss
+++ b/src/stylesheet/public.scss
@@ -2337,7 +2337,6 @@ input[type='number'] {
         display: flex;
         justify-content: center;
         align-items: center;
-        cursor: pointer;
         > p {
           margin: 9px;
           color: #333333;

--- a/src/stylesheet/public.scss
+++ b/src/stylesheet/public.scss
@@ -2013,15 +2013,16 @@ input[type='number'] {
               z-index: 2;
               position: absolute;
               width: 345px;
-              height: 300px;
+              height: 305px;
               left: 0;
               top: 0;
+              border-radius: 5px;
               background: #00000013;
             }
           }
           > section {
             width: 345px;
-            height: 300px;
+            height: 305px;
             padding: 10px;
             box-shadow: 0px 0px 6px #00000029;
             border-radius: 5px;
@@ -2080,28 +2081,26 @@ input[type='number'] {
             }
             > progress {
               width: 100%;
-              margin-top: 10px;
-              height: 5px;
+              margin-top: 5px;
+              height: 10px;
               border: 0;
               vertical-align: 0;
               &::-webkit-progress-bar {
-                height: 5px;
+                height: 10px;
                 border-radius: 5px;
                 border: 0;
-                border-radius: 5px;
                 background: #e6e6e6;
               }
               &::-webkit-progress-value {
                 background: #0099cc;
                 border: 0;
-                border-radius: 5px;
-                height: 5px;
+                height: 10px;
                 border-radius: 5px;
               }
               &::-moz-progress-bar {
                 background: #0099cc;
                 border: 0;
-                height: 5px;
+                height: 10px;
                 border-radius: 5px;
               }
             }

--- a/src/stylesheet/public.scss
+++ b/src/stylesheet/public.scss
@@ -6965,6 +6965,102 @@ input[type='number'] {
         }
       }
     }
+    &__investment-reward {
+      &__burn {
+        padding: 18px 25px 25px 25px;
+        > b {
+          font-size: 15px;
+          color: $font-color;
+        }
+        > div {
+          margin-top: 13px;
+          width: 100%;
+          border-radius: 10px;
+          background: #f0f0f1;
+          padding: 20px 30px;
+          > b {
+            font-size: 30px;
+            text-align: right;
+            display: block;
+            > span {
+              font-size: 25px;
+              margin-left: 5px;
+              color: $gray-font-color;
+            }
+          }
+          margin-bottom: 10px;
+        }
+        > p {
+          font-size: 12px;
+          color: #646464;
+          text-align: right;
+        }
+        border-bottom: 1px solid $gray-line;
+      }
+      &__current {
+        padding: 30px 25px 25px 25px;
+        > div {
+          display: flex;
+          flex-direction: row;
+          justify-content: space-between;
+          align-items: center;
+          > b {
+            font-size: 15px;
+            color: $font-color;
+            > span {
+              margin-left: 5px;
+              color: #646464;
+            }
+          }
+          margin-bottom: 14px;
+        }
+        > section {
+          border: 1px solid #e6e6e6;
+          border-radius: 10px;
+          padding: 18px 25px;
+          > div {
+            display: flex;
+            flex-direction: row;
+            justify-content: space-between;
+            align-items: center;
+            &:first-child {
+              margin-bottom: 10px;
+            }
+            > p {
+              font-size: 15px;
+              color: $font-color;
+              > span {
+                margin-left: 5px;
+                color: #646464;
+              }
+            }
+          }
+        }
+        border-bottom: 1px solid $gray-line;
+      }
+      &__button {
+        display: flex;
+        > button {
+          @include hover__box-shadow--white;
+          flex: 1;
+          height: 47px;
+          margin: 25px;
+          background: #00bfff;
+          border-radius: 35px;
+          cursor: pointer;
+          font-size: 18px;
+          line-height: 47px;
+          color: #fff;
+          border: 0;
+          &.disabled {
+            pointer-events: none;
+            cursor: not-allowed;
+            background-color: #f0f0f1;
+            color: $font-color;
+          }
+        }
+      }
+    }
   }
   @keyframes ldio-17gxvvu9k8u {
     0% {

--- a/src/utiles/formatters.ts
+++ b/src/utiles/formatters.ts
@@ -69,6 +69,11 @@ export const formatCommaSmallZeroDisits = (value: number): string =>
     minimumFractionDigits: 0,
     maximumFractionDigits: 0,
   }).format(value);
+export const formatCommaSmallTwoDisits = (value: number): string =>
+  new Intl.NumberFormat('en', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  }).format(value);
 
 export const toCompact = (value: number): string =>
   new Intl.NumberFormat('en-US', {


### PR DESCRIPTION
나의 예상 수익금과 판매 현황 프로그래스 바를 추가했습니다.

* 마켓 프로그래스 바 계산식 : (오프체인 판매 수량 560000 + 총 nft 판매량 * NFT 달러 가치 10) / 1100000
* 예상 이자율 계산식 : 보유 nft 개수 * (NFT 달러 가치 10 + 이자율 0.39) + 이벤트 보유 수량 (우선은 0으로 고정)
* 수령하기 활성화 조건 : IS_MONEY_POOL_CHARGED 가 true로 변경

총 NFT 개수, 이자율, NFT 달러가치, 오프체인 판매량, 총 수량, 유저 이벤트 값 및 이벤트 종료 여부, 머니풀 상환 여부가 현재 상수로 고정되어있습니다. 
정확한 값을 불러오거나 필요할 때 수정할 수 있도록 개선이 필요합니다.